### PR TITLE
Add link to top feature

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -110,6 +110,7 @@
 //= require cookies
 //= require columns_selector
 //= require budget_edit_associations
+//= require link_to_top
 
 var initialize_modules = function() {
   "use strict";
@@ -164,6 +165,7 @@ var initialize_modules = function() {
     App.ColumnsSelector.initialize();
   }
   App.BudgetEditAssociations.initialize();
+  App.LinkToTop.initialize();
 };
 
 $(function() {

--- a/app/assets/javascripts/link_to_top.js
+++ b/app/assets/javascripts/link_to_top.js
@@ -1,0 +1,16 @@
+(function() {
+  "use strict";
+  App.LinkToTop = {
+    initialize: function() {
+      $(document).scroll(function() {
+        var y = $(this).scrollTop();
+        var link_to_top_scroll = $(window).height() * 20 / 100;
+        if (y > link_to_top_scroll) {
+          $(".link-to-top").fadeIn();
+        } else {
+          $(".link-to-top").fadeOut();
+        }
+      });
+    }
+  };
+}).call(this);

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -479,6 +479,27 @@ a {
   font-weight: bold;
 }
 
+.link-to-top {
+  background: rgba(226, 226, 226, 0.5);
+  border-radius: rem-calc(6);
+  bottom: 48px;
+  display: table;
+  height: rem-calc(48);
+  position: fixed;
+  right: 48px;
+  width: rem-calc(48);
+
+  a {
+    color: $text;
+    display: table-cell;
+    font-size: rem-calc(24);
+    text-align: center;
+    text-decoration: none;
+    vertical-align: middle;
+    width: 100%;
+  }
+}
+
 // 02. Header
 // ----------
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -101,6 +101,7 @@ class Setting < ApplicationRecord
         "feature.remote_census": nil,
         "feature.valuation_comment_notification": true,
         "feature.graphql_api": true,
+        "feature.link_to_top": true,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,
         "homepage.widgets.feeds.proposals": true,

--- a/app/views/layouts/_link_to_top.html.erb
+++ b/app/views/layouts/_link_to_top.html.erb
@@ -1,0 +1,6 @@
+<div class="link-to-top" style="display: none;" data-smooth-scroll>
+  <a href="#body" title="<%= t("layouts.link_to_top.title") %>">
+    <span class="show-for-sr"><%= t("layouts.link_to_top.title") %></span>
+    <span class="fas fa-arrow-up"></span>
+  </a>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -6,7 +6,7 @@
     <%= content_for :head %>
   </head>
 
-  <body class="admin" data-watch-form-message="<%= I18n.t("layouts.admin.watch_form_message") %>">
+  <body id="body" class="admin" data-watch-form-message="<%= I18n.t("layouts.admin.watch_form_message") %>">
     <div class="off-canvas-wrapper">
       <div class="off-canvas-wrapper-inner" data-off-canvas-wrapper>
         <div class="off-canvas position-left" id="offCanvas" data-off-canvas>
@@ -32,6 +32,10 @@
               <%= render "layouts/flash" %>
               <%= render "layouts/officing_booth" if controller.class.parent == Officing && session[:booth_id].present? %>
               <%= yield %>
+
+              <% if feature?(:link_to_top) %>
+                <%= render "layouts/link_to_top" %>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 
     <%= raw setting["html.per_page_code_head"] %>
   </head>
-  <body class="<%= yield (:body_class) %>">
+  <body id="body" class="<%= yield (:body_class) %>">
     <%= raw setting["html.per_page_code_body"] %>
 
     <h1 class="show-for-sr"><%= setting["org_name"] %></h1>
@@ -44,6 +44,10 @@
       <%= render "layouts/flash" %>
 
       <%= yield %>
+
+      <% if feature?(:link_to_top) %>
+        <%= render "layouts/link_to_top" %>
+      <% end %>
 
       <div class="push"></div>
     </div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -216,6 +216,8 @@ en:
           zero: No supports
           one: 1 Support
           other: "Supports"
+    link_to_top:
+      title: "Go back to the top of the page"
     footer:
       accessibility: Accessibility
       conditions: Terms and conditions of use

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -127,6 +127,8 @@ en:
       valuation_comment_notification: "Valuation comment notification"
       valuation_comment_notification_description: "Send an email to all associated users except valuation commenter to budget investment when a new valuation comment is created"
       graphql_api: "GraphQL API"
+      link_to_top: "Link to top"
+      link_to_top_description: "Show a link to return to the top of the page after scrolling"
       dashboard:
         notification_emails: "Dashboard notification emails"
         notification_emails_description: "Enable sending dashboard notification emails to proposal's authors"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -216,6 +216,8 @@ es:
           zero: Sin apoyos
           one: 1 Apoyo
           other: "Apoyos"
+    link_to_top:
+      title: "Volver a la parte superior de la página"
     footer:
       accessibility: Accesibilidad
       conditions: Condiciones de uso

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -130,6 +130,8 @@ es:
       dashboard:
         notification_emails: "Emails del panel de progreso"
         notification_emails_description: "Activar el envío de emails de notificaciones a los autores de las propuestas en la sección de panel de progreso"
+      link_to_top: "Enlace al inicio"
+      link_to_top_description: "Muestra una enlace para volver a la parte superior de la página después de desplazarse"
     remote_census:
       general:
         endpoint: "Endpoint"

--- a/spec/features/link_to_top.rb
+++ b/spec/features/link_to_top.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+describe "Link to top" do
+  scenario "Display if feature is enabled", :js do
+    window_height = page.evaluate_script("window.innerHeight;")
+    scroll = (window_height * 20 / 100) + 1
+
+    visit root_path
+    expect(page).to have_link("Go back to the top of the page", visible: false)
+
+    execute_script "window.scrollTo(0, #{scroll})"
+    expect(page.evaluate_script("window.scrollY;")).not_to eq(0)
+    expect(page).to have_link("Go back to the top of the page", visible: true)
+
+    click_link "Go back to the top of the page"
+    expect(page.evaluate_script("window.scrollY;")).to eq(0)
+
+    login_as(create(:administrator).user)
+
+    visit admin_root_path
+    expect(page).to have_link("Go back to the top of the page", visible: false)
+
+    execute_script "window.scrollTo(0, #{scroll})"
+    expect(page).to have_link("Go back to the top of the page", visible: true)
+    expect(page.evaluate_script("window.scrollY;")).not_to eq(0)
+
+    click_link "Go back to the top of the page"
+    expect(page.evaluate_script("window.scrollY;")).to eq(0)
+  end
+
+  scenario "Do not display if feature is disabled" do
+    Setting["feature.link_to_top"] = false
+
+    visit root_path
+
+    within("#body") do
+      expect(page).not_to have_link "Go back to the top of the page"
+    end
+
+    login_as(create(:administrator).user)
+    visit admin_root_path
+
+    within("#body") do
+      expect(page).not_to have_link "Go back to the top of the page"
+    end
+  end
+end


### PR DESCRIPTION
## Objectives

Add link to top feature, if this feature is enabled show a link to return to the top of the page after scrolling.

## Visual Changes

### Admin feature
![link_to_top](https://user-images.githubusercontent.com/631897/76806818-c8f52400-67e2-11ea-9219-09d8e01057ca.png)

### Link to top working
![link_to_top](https://user-images.githubusercontent.com/631897/76806819-ca265100-67e2-11ea-8756-bc9114faa2f6.gif)

## Notes

It's necessary run `rake settings:add_new_settings` to include the new setting 😌 