### PR TITLE
Groups and headings settings

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -47,6 +47,10 @@ $admin-text:     #434d54;
   h3 {
     color: $admin-title;
     margin: $line-height 0;
+
+    &.inline-block {
+      margin-bottom: 0;
+    }
   }
 
   a {
@@ -288,7 +292,6 @@ $admin-text:     #434d54;
       }
 
       a {
-        color: inherit;
         white-space: nowrap;
       }
     }
@@ -400,6 +403,7 @@ $admin-text:     #434d54;
   }
 
   .button {
+    font-weight: bold;
     min-width: rem-calc(140);
     max-height: $line-height * 2;
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -114,6 +114,19 @@ a {
       position: absolute;
     }
   }
+
+  &.add {
+    font-weight: bold;
+    padding-left: $line-height * 1.5;
+    position: relative;
+
+    &::before {
+      content: "\f0fe";
+      font-family: "Font Awesome 5 Free";
+      left: 10px;
+      position: absolute;
+    }
+  }
 }
 
 .button.hollow {
@@ -415,7 +428,7 @@ a {
   }
 }
 
-.button.float-right ~ .button.float-right {
+.button.float-right + .button.float-right {
   margin: 0 $line-height / 2;
 }
 

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -36,6 +36,16 @@
     <%= f.text_field :main_button_url, placeholder: t("admin.shared.example_url") %>
   </div>
 
+  <% if @budget.persisted? %>
+    <p class="form-section-divider">
+      <span><%= t("admin.budgets.edit.info.groups_and_headings_settings") %></span>
+    </p>
+
+    <div class="small-12 column">
+      <%= render "groups_and_headings" %>
+    </div>
+  <% end %>
+
   <p class="form-section-divider"><span><%= t("admin.budgets.edit.info.staff_settings") %></span></p>
 
   <div class="clear">

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -62,11 +62,13 @@
 
   <%= render "phases" %>
 
-  <p class="form-section-divider"><span><%= t("admin.budgets.edit.info.results_settings") %></span></p>
+  <% if @budget.persisted? %>
+    <p class="form-section-divider"><span><%= t("admin.budgets.edit.info.results_settings") %></span></p>
 
-  <div class="small-12 column">
-    <%= render "admin/shared/show_results_fields", form: f %>
-  </div>
+    <div class="small-12 column">
+      <%= render "admin/shared/show_results_fields", form: f %>
+    </div>
+  <% end %>
 
   <div class="small-12 column">
     <div class="clear small-12 medium-4 large-3 inline-block">

--- a/app/views/admin/budgets/_group_actions.html.erb
+++ b/app/views/admin/budgets/_group_actions.html.erb
@@ -1,0 +1,15 @@
+<%= link_to edit_admin_budget_group_path(@budget, group), class: "icon-link" do %>
+  <span data-tooltip tabindex="1" data-position="bottom" data-alignment="center"
+        title="<%= t("admin.budgets.edit.groups_and_headings.edit_group", name: group.name) %>">
+    <span class="far fa-edit"></span>
+    <span class="show-for-sr"><%= t("admin.budgets.edit.groups_and_headings.edit_group") %></span>
+  </span>
+<% end %>
+
+<%= link_to admin_budget_group_path(@budget, group), method: :delete, class: "icon-link delete" do %>
+  <span data-tooltip tabindex="1" data-position="bottom" data-alignment="center"
+        title="<%= t("admin.budgets.edit.groups_and_headings.delete_group", name: group.name) %>">
+    <span class="far fa-trash-alt"></span>
+    <span class="show-for-sr"><%= t("admin.budgets.edit.groups_and_headings.delete_group") %></span>
+  </span>
+<% end %>

--- a/app/views/admin/budgets/_groups_and_headings.html.erb
+++ b/app/views/admin/budgets/_groups_and_headings.html.erb
@@ -1,0 +1,41 @@
+<% @budget.groups.each do |group| %>
+  <div id="<%= "group_#{group.id}" %>">
+    <%= link_to t("admin.budgets.edit.groups_and_headings.add_heading"),
+              new_admin_budget_group_heading_path(@budget, group),
+              class: "button hollow float-right margin-top add" %>
+
+    <h3 class="inline-block"><%= group.name %></h3>
+
+    <%= render "group_actions", group: group %>
+
+    <p class="help-text">
+      <%= t("admin.budgets.edit.groups_and_headings.max_number_headings") %>
+      <%= group.max_votable_headings %>
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th scope="col"><%= t("admin.budgets.edit.groups_and_headings.headings") %></th>
+          <th scope="col" class="text-right"><%= t("admin.shared.actions") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% group.headings.each do |heading| %>
+          <tr>
+            <td>
+              <%= heading.name %>
+            </td>
+            <td class="text-right">
+              <%= render "headings_actions", group: group, heading: heading %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+
+<%= link_to t("admin.budgets.edit.groups_and_headings.add_group"),
+            new_admin_budget_group_path(@budget),
+            class: "button add" %>

--- a/app/views/admin/budgets/_headings_actions.html.erb
+++ b/app/views/admin/budgets/_headings_actions.html.erb
@@ -1,0 +1,16 @@
+<%= link_to edit_admin_budget_group_heading_path(@budget, group, heading), class: "icon-link" do %>
+  <span data-tooltip tabindex="1" data-position="bottom" data-alignment="center"
+    title="<%= t("admin.budgets.edit.groups_and_headings.edit_heading", name: heading.name) %>">
+    <span class="far fa-edit"></span>
+    <span class="show-for-sr"><%= t("admin.budgets.edit.groups_and_headings.edit_heading") %></span>
+  </span>
+<% end %>
+
+<%= link_to admin_budget_group_heading_path(@budget, group, heading), method: :delete,
+            class: "icon-link delete" do %>
+  <span data-tooltip tabindex="1" data-position="bottom" data-alignment="center"
+    title="<%= t("admin.budgets.edit.groups_and_headings.delete_heading", name: heading.name) %>">
+    <span class="far fa-trash-alt"></span>
+    <span class="show-for-sr"><%= t("admin.budgets.edit.groups_and_headings.delete_heading") %></span>
+  </span>
+<% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -132,6 +132,16 @@ en:
           phases_settings: "Phases settings"
           results_settings: "Results and statistics settings"
           staff_settings: "Administrators and Valuators assigned to the budget"
+          groups_and_headings_settings: "Groups and headings settings"
+        groups_and_headings:
+          edit_group: "Edit group %{name}"
+          delete_group: "Delete group %{name}"
+          headings: "Headings"
+          edit_heading: "Edit heading %{name}"
+          delete_heading: "Delete heading %{name}"
+          max_number_headings: "Maximum number of headings in which a user can vote"
+          add_group: "Add group"
+          add_heading: "Add heading"
       destroy:
         success_notice: Budget deleted successfully
         unable_notice: You cannot delete a budget that has associated investments

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -132,6 +132,16 @@ es:
           phases_settings: "Configuración de las fases"
           results_settings: "Configuración de resultados y estadísticas"
           staff_settings: "Administradores y Evaluadores asigandos al presupuesto"
+          groups_and_headings_settings: "Configuración de grupos y partidas"
+        groups_and_headings:
+          edit_group: "Editar grupo %{name}"
+          delete_group: "Eliminar grupo %{name}"
+          headings: "Partidas"
+          edit_heading: "Editar partida %{name}"
+          delete_heading: "Eliminar partida %{name}"
+          max_number_headings: "Máximo número de partidas en que un usuario puede votar"
+          add_group: "Añadir grupo"
+          add_heading: "Añadir partida"
       destroy:
         success_notice: Presupuesto eliminado correctamente
         unable_notice: No se puede eliminar un presupuesto con proyectos asociados

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -182,6 +182,15 @@ describe "Admin budgets" do
       expect(page).to have_css(".is-invalid-label", text: "Name")
       expect(page).to have_css("small.form-error", text: "has already been taken")
     end
+
+    scenario "Do not show results and stats settings on new budget" do
+      visit new_admin_budget_path
+
+      expect(page).not_to have_content "Results and statistics settings"
+      expect(page).not_to have_content "Show results"
+      expect(page).not_to have_content "Show stats"
+      expect(page).not_to have_content "Show advanced stats"
+    end
   end
 
   context "Create" do
@@ -321,6 +330,15 @@ describe "Admin budgets" do
           end
         end
       end
+    end
+
+    scenario "Show results and stats settings" do
+      visit edit_admin_budget_path(budget)
+
+      expect(page).to have_content "Results and statistics settings"
+      expect(page).to have_content "Show results"
+      expect(page).to have_content "Show stats"
+      expect(page).to have_content "Show advanced stats"
     end
 
     scenario "Show CTA button in public site if added" do

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -341,6 +341,57 @@ describe "Admin budgets" do
       expect(page).to have_content "Show advanced stats"
     end
 
+    scenario "Show groups and headings settings" do
+      visit edit_admin_budget_path(budget)
+
+      expect(page).to have_content "Groups and headings settings"
+      expect(page).to have_link "Add group"
+      expect(page).to have_link("Add heading", count: budget.groups.count)
+
+      budget.groups.each do |group|
+        expect(page).to have_content group.name
+        expect(page).to have_content "Maximum number of headings in which a user can "\
+                                     "vote #{group.max_votable_headings}"
+        expect(page).to have_link "Edit group #{group.name}"
+        expect(page).to have_link "Delete group #{group.name}"
+
+        group.headings.each do |heading|
+          expect(page).to have_content heading.name
+          expect(page).to have_link "Edit heading #{heading.name}"
+          expect(page).to have_link "Delete heading #{heading.name}"
+        end
+      end
+    end
+
+    scenario "Add group from edit view" do
+      visit edit_admin_budget_path(budget)
+
+      click_link "Add group"
+
+      fill_in "Group name", with: "New group"
+      click_button "Create new group"
+
+      visit edit_admin_budget_path(budget)
+      expect(page).to have_content "New group"
+    end
+
+    scenario "Add heading from edit view" do
+      visit edit_admin_budget_path(budget)
+
+      budget.groups.each do |group|
+        within "#group_#{group.id}" do
+          click_link "Add heading"
+
+          fill_in "Heading name", with: "New heading for #{group.name}"
+          fill_in "Amount", with: "1000"
+          click_button "Create new heading"
+        end
+
+        expect(page).to have_content "New heading for #{group.name}"
+        expect(page).to have_content("€1,000", count: budget.groups.count)
+      end
+    end
+
     scenario "Show CTA button in public site if added" do
       visit edit_admin_budget_path(budget)
       expect(page).to have_content("Main call to action (optional)")


### PR DESCRIPTION
## Objectives

- Show results and stats settings only in budget edit view
- Add groups and headings settings in admin budget edit

## Visual Changes

![results_stats](https://user-images.githubusercontent.com/631897/76956763-f17d3b00-6914-11ea-8661-2a225d3164db.png)

![group_and_headings](https://user-images.githubusercontent.com/631897/76956768-f346fe80-6914-11ea-95cf-1abc1195be94.png)
