### PR TITLE
Add validation for button URL when button name is provided

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -26,6 +26,7 @@ class Budget < ApplicationRecord
   validates :phase, inclusion: { in: Budget::Phase::PHASE_KINDS }
   validates :currency_symbol, presence: true
   validates :slug, presence: true, format: /\A[a-z0-9\-_]+\z/
+  validates :main_button_url, presence: true, if: -> { main_button_text.present? }
 
   has_many :investments, dependent: :destroy
   has_many :ballots, dependent: :destroy

--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -22,6 +22,7 @@ class Budget
     validates_translation :description, length: { maximum: DESCRIPTION_MAX_LENGTH }
     validates :budget, presence: true
     validates :kind, presence: true, uniqueness: { scope: :budget }, inclusion: { in: PHASE_KINDS }
+    validates :main_button_url, presence: true, if: -> { main_button_text.present? }
     validate :invalid_dates_range?
     validate :prev_phase_dates_valid?
     validate :next_phase_dates_valid?

--- a/spec/features/admin/budget_phases_spec.rb
+++ b/spec/features/admin/budget_phases_spec.rb
@@ -46,19 +46,11 @@ describe "Admin budget phases" do
       end
     end
 
-    scenario "Show CTA only if there is a link" do
+    scenario "Show CTA button in public site if added" do
       visit edit_admin_budget_budget_phase_path(budget, budget.current_phase)
-
       expect(page).to have_content "Main call to action (optional)"
+
       fill_in "Text on the button", with: "Button on the phase"
-      click_button "Save changes"
-
-      visit budgets_path
-      within "##{budget.current_phase.id}" do
-        expect(page).not_to have_link("Button on the phase", href: "https://consulproject.org")
-      end
-
-      visit edit_admin_budget_budget_phase_path(budget, budget.current_phase)
       fill_in "The button takes you to (add a link)", with: "https://consulproject.org"
       click_button "Save changes"
 

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -323,16 +323,11 @@ describe "Admin budgets" do
       end
     end
 
-    scenario "Show CTA only if there is a link" do
+    scenario "Show CTA button in public site if added" do
       visit edit_admin_budget_path(budget)
       expect(page).to have_content("Main call to action (optional)")
+
       fill_in "Text on the button", with: "Participate now"
-      click_button "Update Budget"
-
-      visit budgets_path
-      expect(page).not_to have_link("Participate now", href: "https://consulproject.org")
-
-      visit edit_admin_budget_path(budget)
       fill_in "The button takes you to (add a link)", with: "https://consulproject.org"
       click_button "Update Budget"
 

--- a/spec/models/budget/phase_spec.rb
+++ b/spec/models/budget/phase_spec.rb
@@ -111,6 +111,28 @@ describe Budget::Phase do
         expect(informing_phase).to be_valid
       end
     end
+
+    describe "main_button_url" do
+      it "is not required if main_button_text is not provided" do
+        valid_budget = build(:budget,
+                             name_en: "object name",
+                             main_button_text: "button text",
+                             main_button_url: "http://domain.com")
+
+        expect(valid_budget).to be_valid
+      end
+
+      it "is required if main_button_text is provided" do
+        invalid_budget = build(:budget,
+                               name_en: "object name",
+                               main_button_text: "button text")
+
+        expect(invalid_budget).not_to be_valid
+        expect(invalid_budget.errors.count).to be 1
+        expect(invalid_budget.errors[:main_button_url].count).to be 1
+        expect(invalid_budget.errors[:main_button_url].first).to eq "can't be blank"
+      end
+    end
   end
 
   describe "#save" do

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -84,6 +84,28 @@ describe Budget do
     end
   end
 
+  describe "main_button_url" do
+    it "is not required if main_button_text is not provided" do
+      valid_budget = build(:budget,
+                           name_en: "object name",
+                           main_button_text: "button text",
+                           main_button_url: "http://domain.com")
+
+      expect(valid_budget).to be_valid
+    end
+
+    it "is required if main_button_text is provided" do
+      invalid_budget = build(:budget,
+                             name_en: "object name",
+                             main_button_text: "button text")
+
+      expect(invalid_budget).not_to be_valid
+      expect(invalid_budget.errors.count).to be 1
+      expect(invalid_budget.errors[:main_button_url].count).to be 1
+      expect(invalid_budget.errors[:main_button_url].first).to eq "can't be blank"
+    end
+  end
+
   describe "phase" do
     it "is validated" do
       Budget::Phase::PHASE_KINDS.each do |phase|


### PR DESCRIPTION
## Objectives

For budgets and for budget phases, add a validation that will require to not leave the URL blank if a text for the button is provided