### PR TITLE
Add link to remove budget on budget admin index

### DIFF
--- a/app/views/admin/budgets/_table_actions.html.erb
+++ b/app/views/admin/budgets/_table_actions.html.erb
@@ -14,12 +14,24 @@
   </span>
 <% end %>
 
+<%= link_to admin_budget_path(budget), class: "icon-link delete", method: :delete,
+    data: { confirm: t("admin.actions.confirm_delete",
+                       resource_name: t("admin.budgets.shared.resource_name"),
+                       name: budget.name) } do %>
+  <span data-tooltip tabindex="1" data-position="bottom" data-alignment="center"
+        title="<%= t("admin.budgets.index.delete") %>">
+    <span class="far fa-trash-alt"></span>
+    <span class="show-for-sr"><%= t("admin.budgets.index.delete") %></span>
+  </span>
+<% end %>
+
 <a data-toggle="budget-admin-actions-<%= budget.id %>" class="icon-link">
   <span class="fas fa-ellipsis-v"></span>
 </a>
 
-<div class="dropdown-pane" id="budget-admin-actions-<%= budget.id %>" data-hover="true" data-hover-pane="true"
-     data-position="bottom" data-alignment="right" data-dropdown>
+<div class="dropdown-pane" id="budget-admin-actions-<%= budget.id %>" data-hover="true"
+     data-hover-pane="true" data-position="bottom" data-alignment="center" data-dropdown
+     data-allow-bottom-overlap="false">
   <ul>
     <li>
       <%= link_to t("admin.budgets.index.budget_investments"),

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -14,6 +14,7 @@ en:
       edit: Edit
       configure: Configure
       delete: Delete
+      confirm_delete: "Are you sure? This action will delete %{resource_name} '%{name}' and can't be undone."
     officing_booth:
       title: "You are officing the booth located at %{booth}. If this is not correct, do not continue and call the help phone number. Thank you."
     banners:
@@ -90,6 +91,7 @@ en:
         help_block: "Participatory budgets allow citizens to propose and decide directly how to spend part of the budget, with monitoring and rigorous evaluation of proposals by the institution."
         type_single: Single heading
         type_multiple: Multiple headings
+        delete: "Delete budget"
       create:
         button:
           continue: "Continue to groups"
@@ -156,6 +158,7 @@ en:
         timeline_groups: Groups
         timeline_headings: Headings
         timeline_phases: Phases
+        resource_name: "the budget"
     budget_groups:
       name: "Name"
       headings_name: "Headings"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -14,6 +14,7 @@ es:
       edit: Editar
       configure: Configurar
       delete: Borrar
+      confirm_delete: "¿Estás seguro? Esta acción borrará %{resource_name} '%{name}' y no se puede deshacer."
     officing_booth:
       title: "Estás ahora mismo en la mesa ubicada en %{booth}. Si esto no es correcto no sigas adelante y llama al teléfono de incidencias. Gracias."
     banners:
@@ -90,6 +91,7 @@ es:
         help_block: "Los presupuestos participativos permiten que los ciudadanos propongan y decidan de manera directa cómo gastar parte del presupuesto, con un seguimiento y evaluación riguroso de las propuestas por parte de la institución."
         type_single: Partida única
         type_multiple: Múltiples partidas
+        delete: "Eliminar presupuesto"
       create:
         button:
           continue: "Continuar a grupos"
@@ -156,6 +158,7 @@ es:
         timeline_groups: Grupos
         timeline_headings: Partidas
         timeline_phases: Fases
+        resource_name: "el presupuesto"
     budget_groups:
       name: "Nombre"
       headings_name: "Partidas"

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -158,6 +158,26 @@ describe "Admin budgets" do
         end
       end
     end
+
+    scenario "Delete budget from index", :js do
+      budget = create(:budget)
+      visit admin_budgets_path
+
+      within "#budget_#{budget.id}" do
+        click_link "Delete budget"
+      end
+
+      page.driver.browser.switch_to.alert do
+        expect(page).to have_content "Are you sure? This action will delete the budget '#{budget.name}' "\
+                                     "and can't be undone."
+      end
+
+      accept_confirm
+
+      expect(page).to have_content("Budget deleted successfully")
+      expect(page).to have_content("There are no budgets.")
+      expect(page).not_to have_content budget.name
+    end
   end
 
   context "New" do


### PR DESCRIPTION
## Objectives

Add a link to remove the budget on the budget admin index table.

## Visual Changes
![Screenshot 2020-04-03 at 10 49 51](https://user-images.githubusercontent.com/631897/78345654-343e4480-759e-11ea-8bba-e109991fbe7b.png)
