### PR TITLE
New budget investment form

### DIFF
--- a/app/assets/stylesheets/_consul_settings.scss
+++ b/app/assets/stylesheets/_consul_settings.scss
@@ -22,6 +22,7 @@ $dark:              darken($brand, 10%);
 $text:              #222;
 $text-medium:       #515151;
 $text-light:        #bfbfbf;
+$label:             #2f82b4;
 
 $border:            #dee0e3;
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -230,6 +230,30 @@ a {
 
 .light {
   background: $light;
+
+  &.expand {
+    background: $light;
+    clear: both;
+    position: relative;
+
+    &::before,
+    &::after {
+      background: $light;
+      content: "";
+      height: 100%;
+      position: absolute;
+      top: 0;
+      width: 100%;
+    }
+
+    &::before {
+      right: 100%;
+    }
+
+    &::after {
+      left: 100%;
+    }
+  }
 }
 
 .highlight {
@@ -245,6 +269,7 @@ a {
   margin: 0 auto (-$line-height) * 12;
   height: auto !important;
   height: 100%;
+  overflow: hidden;
 }
 
 .footer,
@@ -1095,6 +1120,7 @@ footer {
 form {
 
   label {
+    color: $label;
     font-size: $base-font-size;
     font-weight: bold;
     line-height: $line-height;
@@ -1102,6 +1128,15 @@ form {
 
   fieldset legend {
     font-weight: bold;
+  }
+
+  select {
+    border: 2px solid #d2d7dc;
+    border-radius: rem-calc(4);
+
+    &:not(.locale-switcher) {
+      min-height: $line-height * 2;
+    }
   }
 
   [type="radio"] {
@@ -1118,7 +1153,10 @@ form {
   }
 
   [type]:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]):not(.close-button) {
-    background: #f8f8f8;
+    background: #fff;
+    border: 2px solid #d2d7dc;
+    border-radius: rem-calc(4);
+    box-shadow: none;
     height: $line-height * 2;
     margin-bottom: rem-calc(16);
 
@@ -1151,10 +1189,20 @@ form {
 
   .checkbox,
   .radio {
-    display: inline-block;
+    color: $text;
     font-weight: normal;
     line-height: $line-height;
     vertical-align: middle;
+  }
+
+  .required {
+
+    label {
+
+      &::after {
+        content: "*";
+      }
+    }
   }
 }
 
@@ -1169,6 +1217,52 @@ form {
 
 .translation-locale {
   padding-top: $line-height;
+}
+
+.form-label {
+  color: $label;
+  font-weight: bold;
+}
+
+.subtitle-form {
+  color: #000;
+  font-size: rem-calc(36);
+  font-weight: bold;
+  margin-bottom: $line-height * 2;
+  padding-top: $line-height * 3;
+  text-transform: uppercase;
+}
+
+.submit-form-container {
+  position: relative;
+
+  &::before,
+  &::after {
+    background: $light;
+    content: "";
+    height: 100%;
+    position: absolute;
+    top: 48px;
+    width: 150%;
+    z-index: -1;
+  }
+
+  &::before {
+    left: -100%;
+  }
+
+  &::after {
+    right: -100%;
+  }
+}
+
+.submit-form-box {
+  background: #fff;
+  border: 6px solid $border;
+  border-radius: rem-calc(12);
+  margin-top: $line-height * 2;
+  padding: $line-height * 2 $line-height;
+  text-align: center;
 }
 
 // 07. Callout

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -398,6 +398,20 @@
         right: 0;
       }
     }
+
+    &.header-single-heading {
+
+      .header-icon {
+
+        @include breakpoint(large) {
+          top: 80px;
+        }
+      }
+
+      &::after {
+        padding-top: $line-height;
+      }
+    }
   }
 }
 

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -324,6 +324,83 @@
   @include direct-uploads;
 }
 
+
+.budget-investment-new {
+
+  .header {
+    background: $brand;
+    border-bottom-right-radius: rem-calc(12);
+    border-top-right-radius: rem-calc(12);
+    color: #fff;
+    margin-top: $line-height * 2;
+    padding: $line-height * 2 0;
+    position: relative;
+
+    h1 {
+      font-size: rem-calc(36);
+
+      @include breakpoint(large) {
+        font-size: rem-calc(44);
+      }
+    }
+
+    &::before {
+      background: $brand;
+      border: 4px solid $brand;
+      content: "";
+      height: 100%;
+      position: absolute;
+      top: 0;
+      right: 100%;
+      width: 100%;
+      z-index: 1;
+    }
+
+    &::after {
+      background: #fff;
+      border: 4px solid $brand;
+      border-bottom-right-radius: rem-calc(12);
+      border-top-right-radius: rem-calc(12);
+      clip-path: polygon(20% 0, 100% 1%, 100% 100%, 20% 100%, 5% 50%);
+      color: $brand;
+      content: "\f1ad";
+      display: none;
+      font-family: "Font Awesome 5 Free";
+      font-size: rem-calc(100);
+      height: 100%;
+      padding-left: $line-height;
+      padding-top: $line-height;
+      position: absolute;
+      text-align: center;
+      top: 0;
+      right: 0;
+      width: rem-calc(160);
+
+      @include breakpoint(medium) {
+        display: block;
+      }
+
+      @include breakpoint(large) {
+        padding-top: 0;
+        width: rem-calc(200);
+      }
+    }
+
+    .header-icon {
+      display: block;
+      font-size: rem-calc(36);
+      line-height: rem-calc(60);
+
+      @include breakpoint(large) {
+        font-size: rem-calc(80);
+        padding-right: rem-calc(240);
+        position: absolute;
+        right: 0;
+      }
+    }
+  }
+}
+
 // 03. Show participation
 // ----------------------
 

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -3,9 +3,14 @@
   <%= render "shared/errors", resource: @investment %>
 
   <div class="row column">
-    <div class="small-12 medium-8 column">
-      <%= f.select :heading_id, budget_heading_select_options(@budget), { include_blank: true, } %>
-    </div>
+    <% if @budget.single_heading? %>
+      <%= f.hidden_field :heading_id, value: @budget.headings.first.id %>
+    <% else %>
+      <div class="small-12 medium-8 column">
+        <%= f.select :heading_id, budget_heading_select_options(@budget), { include_blank: true } %>
+      </div>
+    <% end %>
+
     <div class="row">
       <div class="small-12 column">
         <%= render "shared/globalize_locales", resource: @investment %>

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -2,110 +2,120 @@
 
   <%= render "shared/errors", resource: @investment %>
 
-  <div class="row column">
-    <% if @budget.single_heading? %>
-      <%= f.hidden_field :heading_id, value: @budget.headings.first.id %>
-    <% else %>
-      <div class="small-12 medium-8 column">
-        <%= f.select :heading_id, budget_heading_select_options(@budget), { include_blank: true } %>
-      </div>
-    <% end %>
-
+  <div class="light expand">
     <div class="row">
       <div class="small-12 column">
-        <%= render "shared/globalize_locales", resource: @investment %>
+        <p class="subtitle-form"><%= t("shared.required") %></p>
       </div>
+
+      <% if @budget.single_heading? %>
+        <%= f.hidden_field :heading_id, value: @budget.headings.first.id %>
+      <% else %>
+        <div class="small-12 medium-6 column required">
+          <%= f.select :heading_id, budget_heading_select_options(@budget), { include_blank: true } %>
+        </div>
+      <% end %>
+
+      <div class="row">
+        <div class="small-12 column">
+          <%= render "shared/globalize_locales", resource: @investment %>
+        </div>
+      </div>
+
+      <%= f.translatable_fields do |translations_form| %>
+        <div class="small-12 column required">
+          <%= translations_form.text_field :title,
+                maxlength: Budget::Investment.title_max_length,
+                data: { js_suggest_result: "js_suggest_result",
+                        js_suggest: ".js-suggest",
+                        js_url: suggest_budget_investments_path(@budget) } %>
+        </div>
+        <div class="js-suggest" data-locale="<%= translations_form.locale %>"></div>
+
+        <div class="small-12 column end required">
+          <%= translations_form.text_area :description,
+                maxlength: Budget::Investment.description_max_length,
+                class: "html-area" %>
+        </div>
+      <% end %>
     </div>
-
-    <%= f.translatable_fields do |translations_form| %>
-      <div class="small-12 column">
-        <%= translations_form.text_field :title,
-              maxlength: Budget::Investment.title_max_length,
-              data: { js_suggest_result: "js_suggest_result",
-                      js_suggest: ".js-suggest",
-                      js_url: suggest_budget_investments_path(@budget) } %>
-      </div>
-      <div class="js-suggest" data-locale="<%= translations_form.locale %>"></div>
-
-      <div class="small-12 column">
-        <%= translations_form.text_area :description,
-              maxlength: Budget::Investment.description_max_length,
-              class: "html-area" %>
-      </div>
-    <% end %>
 
     <%= f.invisible_captcha :subtitle %>
 
-    <% if feature?(:allow_images) %>
-      <div class="images small-12 column">
-        <%= render "images/nested_image", imageable: @investment, f: f %>
-      </div>
-    <% end %>
-
-    <% if feature?(:allow_attached_documents) %>
-      <div class="documents small-12 column">
-        <%= render "documents/nested_documents", documentable: @investment, f: f %>
-      </div>
-    <% end %>
-
-    <% if feature?(:map) %>
-      <div class="small-12 column">
-
-        <%= render "map_locations/form_fields",
-                   form:     f,
-                   map_location: @investment.map_location || MapLocation.new,
-                   label:    t("budgets.investments.form.map_location"),
-                   help:     t("budgets.investments.form.map_location_instructions"),
-                   remove_marker_label: t("budgets.investments.form.map_remove_marker"),
-                   parent_class: "budget_investment",
-                   i18n_namespace: "budgets.investments" %>
-
-      </div>
-    <% end %>
-
     <div class="small-12 column">
-      <%= f.text_field :location %>
+      <p class="subtitle-form"><%= t("shared.optional") %></p>
+    </div>
+  </div>
+
+  <% if feature?(:allow_images) %>
+    <div class="images small-12 column">
+      <%= render "images/nested_image", imageable: @investment, f: f %>
+    </div>
+  <% end %>
+
+  <% if feature?(:allow_attached_documents) %>
+    <div class="documents small-12 column">
+      <%= render "documents/nested_documents", documentable: @investment, f: f %>
+    </div>
+  <% end %>
+
+  <% if feature?(:map) %>
+    <div class="small-12 column">
+      <%= render "map_locations/form_fields",
+                 form:     f,
+                 map_location: @investment.map_location || MapLocation.new,
+                 label:    t("budgets.investments.form.map_location"),
+                 help:     t("budgets.investments.form.map_location_instructions"),
+                 remove_marker_label: t("budgets.investments.form.map_remove_marker"),
+                 parent_class: "budget_investment",
+                 i18n_namespace: "budgets.investments" %>
+
+    </div>
+  <% end %>
+
+  <div class="small-12 column">
+    <%= f.text_field :location %>
+  </div>
+
+  <div class="small-12 column">
+    <%= f.text_field :organization_name %>
+  </div>
+
+  <div class="small-12 column">
+    <%= f.label :tag_list, t("budgets.investments.form.tags_label") %>
+    <p class="help-text" id="tags-list-help-text"><%= t("budgets.investments.form.tags_instructions") %></p>
+
+    <div id="category_tags" class="tags">
+      <%= f.label :category_tag_list, t("budgets.investments.form.tag_category_label") %>
+      <% @categories.each do |tag| %>
+        <a class="js-add-tag-link"><%= tag.name %></a>
+      <% end %>
     </div>
 
-    <div class="small-12 column">
-      <%= f.text_field :organization_name %>
-    </div>
+    <br>
+    <%= f.text_field :tag_list, value: @investment.tag_list.to_s,
+                      label: false,
+                      placeholder: t("budgets.investments.form.tags_placeholder"),
+                      aria: { describedby: "tags-list-help-text" },
+                      class: "js-tag-list tag-autocomplete",
+                      data: { js_url: suggest_tags_path } %>
+  </div>
 
-    <div class="small-12 column">
-      <%= f.label :tag_list, t("budgets.investments.form.tags_label") %>
-      <p class="help-text" id="tags-list-help-text"><%= t("budgets.investments.form.tags_instructions") %></p>
+  <div class="clear"></div>
+  <div class="submit-form-container">
+    <div class="small-12 medium-9 small-centered submit-form-box required">
+      <% unless current_user.manager? %>
+        <p class="form-label"><%= t("shared.required_fields") %></p>
 
-      <div id="category_tags" class="tags">
-        <%= f.label :category_tag_list, t("budgets.investments.form.tag_category_label") %>
-        <% @categories.each do |tag| %>
-          <a class="js-add-tag-link"><%= tag.name %></a>
-        <% end %>
-      </div>
-
-      <br>
-      <%= f.text_field :tag_list, value: @investment.tag_list.to_s,
-                        label: false,
-                        placeholder: t("budgets.investments.form.tags_placeholder"),
-                        aria: { describedby: "tags-list-help-text" },
-                        class: "js-tag-list tag-autocomplete",
-                        data: { js_url: suggest_tags_path } %>
-    </div>
-
-    <% unless current_user.manager? %>
-
-      <div class="small-12 column">
         <%= f.check_box :terms_of_service,
           title: t("form.accept_terms_title"),
           label: t("form.accept_terms",
                    policy: link_to(t("form.policy"), "/privacy", target: "blank"),
                    conditions: link_to(t("form.conditions"), "/conditions", target: "blank")
                   ) %>
-      </div>
+      <% end %>
 
-    <% end %>
-
-    <div class="actions small-12 medium-6 large-4 end column">
-      <%= f.submit(nil, class: "button expanded") %>
+      <%= f.submit(nil, class: "button large margin-top") %>
     </div>
   </div>
 <% end %>

--- a/app/views/budgets/investments/new.html.erb
+++ b/app/views/budgets/investments/new.html.erb
@@ -3,10 +3,16 @@
   <div class="small-12 column light expand padding-top">
     <%= back_link_to budgets_path %>
 
-    <div class="header">
+    <div class="header <%= "header-single-heading" if @budget.single_heading? %>">
       <span class="fas fa-chart-pie header-icon"></span>
 
       <h1 class="inline-block"><%= t("budgets.investments.form.title") %></h1>
+      <% if @budget.single_heading? %>
+        <h2>
+          <%= @budget.headings.first.name %>
+          (<%= @budget.formatted_heading_price(@budget.headings.first) %>)
+        </h2>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/budgets/investments/new.html.erb
+++ b/app/views/budgets/investments/new.html.erb
@@ -1,7 +1,16 @@
-<div class="budget-investment-new row">
-  <div class="small-12 medium-9 column">
-    <h1><%= t("management.budget_investments.create") %></h1>
+<div class="budget-investment-new no-margin-top row">
 
+  <div class="small-12 column light expand padding-top">
+    <%= back_link_to budgets_path %>
+
+    <div class="header">
+      <span class="fas fa-chart-pie header-icon"></span>
+
+      <h1 class="inline-block"><%= t("budgets.investments.form.title") %></h1>
+    </div>
+  </div>
+
+  <div class="small-12 column">
     <%= render "/budgets/investments/form", form_url: budget_investments_path(@budget) %>
   </div>
 </div>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -64,6 +64,7 @@ en:
       milestones: Milestones
     investments:
       form:
+        title: "Create a budget investment"
         tag_category_label: "Categories"
         tags_instructions: "Tag this proposal. You can choose from proposed categories or add your own"
         tags_label: Tags

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -788,6 +788,9 @@ en:
         zero: "0 languages in use"
         one: "1 language in use"
         other: "%{count} languages in use"
+    optional: "Optional"
+    required: "Required"
+    required_fields: "All fields marked with a (*) are required"
   social:
     facebook: "%{org} Facebook"
     twitter: "%{org} Twitter"

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -64,6 +64,7 @@ es:
       milestones: Seguimiento de proyectos
     investments:
       form:
+        title: "Crear nuevo proyecto"
         tag_category_label: "Categorías"
         tags_instructions: "Etiqueta este proyecto. Puedes elegir entre las categorías propuestas o introducir las que desees"
         tags_label: Etiquetas

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -786,6 +786,9 @@ es:
         zero: "0 idiomas en uso"
         one: "1 idioma en uso"
         other: "%{count} idiomas en uso"
+    optional: "Opcional"
+    required: "Obligatorio"
+    required_fields: "Todos los campos marcados con un (*) son obligatorios"
   social:
     facebook: "Facebook de %{org}"
     twitter: "Twitter de %{org}"

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -894,6 +894,8 @@ describe "Budget Investments" do
 
       visit new_budget_investment_path(budget)
 
+      expect(page).to have_content("#{heading.name} (#{budget.formatted_heading_price(heading)})")
+
       expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
                                      visible: false)
 
@@ -925,6 +927,8 @@ describe "Budget Investments" do
       login_as(author)
 
       visit new_budget_investment_path(budget)
+
+      expect(page).not_to have_content("#{heading.name} (#{budget.formatted_heading_price(heading)})")
 
       within("#budget_investment_heading_id") do
         expect(page).to have_selector("option[value='#{heading.id}']")

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -855,7 +855,9 @@ describe "Budget Investments" do
       login_as(author)
       visit new_budget_investment_path(budget)
 
-      select  heading.name, from: "budget_investment_heading_id"
+      expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                     visible: false)
+
       fill_in "Title", with: "I am a bot"
       fill_in "budget_investment_subtitle", with: "This is the honeypot"
       fill_in "Description", with: "This is the description"
@@ -874,10 +876,12 @@ describe "Budget Investments" do
       login_as(author)
       visit new_budget_investment_path(budget)
 
-      select  heading.name, from: "budget_investment_heading_id"
+      expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                     visible: false)
+
       fill_in "Title", with: "I am a bot"
       fill_in "Description", with: "This is the description"
-      check   "budget_investment_terms_of_service"
+      check   "I agree to the Privacy Policy and the Terms and conditions of use"
 
       click_button "Create Investment"
 
@@ -885,12 +889,50 @@ describe "Budget Investments" do
       expect(page).to have_current_path(new_budget_investment_path(budget))
     end
 
-    scenario "Create" do
+    scenario "Create with single heading" do
       login_as(author)
 
       visit new_budget_investment_path(budget)
 
-      select  heading.name, from: "budget_investment_heading_id"
+      expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                     visible: false)
+
+      fill_in "Title", with: "Build a skyscraper"
+      fill_in "Description", with: "I want to live in a high tower over the clouds"
+      fill_in "Location additional info", with: "City center"
+      fill_in "If you are proposing in the name of a collective/organization, "\
+              "or on behalf of more people, write its name", with: "T.I.A."
+      fill_in "Tags", with: "Towers"
+      check   "I agree to the Privacy Policy and the Terms and conditions of use"
+
+      click_button "Create Investment"
+
+      expect(page).to have_content "Investment created successfully"
+      expect(page).to have_content "Build a skyscraper"
+      expect(page).to have_content "I want to live in a high tower over the clouds"
+      expect(page).to have_content "City center"
+      expect(page).to have_content "T.I.A."
+      expect(page).to have_content "Towers"
+
+      visit user_url(author, filter: :budget_investments)
+      expect(page).to have_content "1 Investment"
+      expect(page).to have_content "Build a skyscraper"
+    end
+
+    scenario "Create with multiple headings" do
+      heading2 = create(:budget_heading, budget: budget)
+      heading3 = create(:budget_heading, budget: budget)
+      login_as(author)
+
+      visit new_budget_investment_path(budget)
+
+      within("#budget_investment_heading_id") do
+        expect(page).to have_selector("option[value='#{heading.id}']")
+        expect(page).to have_selector("option[value='#{heading2.id}']")
+        expect(page).to have_selector("option[value='#{heading3.id}']")
+      end
+
+      select  heading2.name, from: "budget_investment_heading_id"
       fill_in "Title", with: "Build a skyscraper"
       fill_in "Description", with: "I want to live in a high tower over the clouds"
       fill_in "budget_investment_location", with: "City center"

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -343,7 +343,9 @@ describe "Emails" do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
-      select  heading.name, from: "budget_investment_heading_id"
+      expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                     visible: false)
+
       fill_in "Title", with: "Build a hospital"
       fill_in "Description", with: "We have lots of people that require medical attention"
       check   "budget_investment_terms_of_service"

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -62,7 +62,9 @@ describe "Budget Investments" do
         expect(page).to have_content user.document_number
       end
 
-      select "Health", from: "budget_investment_heading_id"
+      expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                     visible: false)
+
       fill_in "Title", with: "Build a park in my neighborhood"
       fill_in "Description", with: "There is no parks here..."
       fill_in "budget_investment_location", with: "City center"

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -66,7 +66,9 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  heading.name, from: "budget_investment_heading_id"
+    expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                   visible: false)
+
     fill_in "Title", with: "Build a skyscraper"
     fill_in "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"
@@ -85,7 +87,9 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  heading.name, from: "budget_investment_heading_id"
+    expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                   visible: false)
+
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
     check "budget_investment_terms_of_service"
@@ -109,7 +113,9 @@ describe "Tags" do
     visit budget_path(budget)
     click_link "Create a budget investment"
 
-    select  heading.name, from: "budget_investment_heading_id"
+    expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                   visible: false)
+
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
     check "budget_investment_terms_of_service"
@@ -133,7 +139,9 @@ describe "Tags" do
     visit budget_investments_path(budget, heading_id: heading.id)
     click_link "Create a budget investment"
 
-    select  heading.name, from: "budget_investment_heading_id"
+    expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                   visible: false)
+
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
     check "budget_investment_terms_of_service"
@@ -154,7 +162,9 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  heading.name, from: "budget_investment_heading_id"
+    expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                   visible: false)
+
     fill_in "Title", with: "Build a skyscraper"
     fill_in "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"
@@ -172,7 +182,9 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  heading.name, from: "budget_investment_heading_id"
+    expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
+                                   visible: false)
+
     fill_in "Title", with: "Build a skyscraper"
     fill_in "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"

--- a/spec/features/translatable_spec.rb
+++ b/spec/features/translatable_spec.rb
@@ -47,7 +47,9 @@ describe "Public area translatable records" do
       fill_in "Title", with: "Titre en Français"
       fill_in_ckeditor "Description", with: "Contenu en Français"
 
-      select "Everywhere", from: "budget_investment_heading_id"
+      expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{budget.id}\"]",
+                                     visible: false)
+
       check "budget_investment_terms_of_service"
       click_button "Create Investment"
 
@@ -76,7 +78,9 @@ describe "Public area translatable records" do
       fill_in "Title", with: "Titre en Français"
       fill_in_ckeditor "Description", with: "Contenu en Français"
 
-      select "Everywhere", from: "budget_investment_heading_id"
+      expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{budget.id}\"]",
+                                     visible: false)
+
       check "budget_investment_terms_of_service"
       click_button "Create Investment"
 
@@ -99,7 +103,9 @@ describe "Public area translatable records" do
       visit new_budget_investment_path(budget)
       click_link "Remove language"
 
-      select "Everywhere", from: "budget_investment_heading_id"
+      expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{budget.id}\"]",
+                                     visible: false)
+
       check "budget_investment_terms_of_service"
       click_button "Create Investment"
 

--- a/spec/shared/features/mappable.rb
+++ b/spec/shared/features/mappable.rb
@@ -256,7 +256,6 @@ def validate_latitude_longitude(mappable_factory_name)
 end
 
 def fill_in_budget_investment_form
-  page.select mappable.heading.name_scoped_by_group, from: :budget_investment_heading_id
   fill_in "Title", with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
   check :budget_investment_terms_of_service

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -355,7 +355,6 @@ def documentable_fill_new_valid_dashboard_action
 end
 
 def documentable_fill_new_valid_budget_investment
-  page.select documentable.heading.name_scoped_by_group, from: :budget_investment_heading_id
   fill_in "Title", with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
   check :budget_investment_terms_of_service

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -286,7 +286,6 @@ def imageable_fill_new_valid_budget
 end
 
 def imageable_fill_new_valid_budget_investment
-  page.select imageable.heading.name_scoped_by_group, from: :budget_investment_heading_id
   fill_in "Title", with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
   check :budget_investment_terms_of_service


### PR DESCRIPTION
## Objectives

- Hide single heading select on new budget investment form
- Update styles and layout for new budget investment form
- Show heading name and amount on single heading new form
## Visual Changes

### Header for a budget with a single heading
![single](https://user-images.githubusercontent.com/631897/78659697-3b31c380-78cc-11ea-9d96-1a640eb1b721.png)

### Header for a budget with multiple headings
![multiple](https://user-images.githubusercontent.com/631897/78659690-38cf6980-78cc-11ea-9c8e-a6e1daec00d5.png)

### Complete form
![form_single_heading](https://user-images.githubusercontent.com/631897/78610984-418d5480-7866-11ea-832b-3a7b0e62228b.png)
