### PR TITLE
Unify budget landing pages

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1338,6 +1338,9 @@
   &.budget {
     background: $budget;
     color: #fff;
+  }
+
+  &.budget:not(.button) {
     min-height: $line-height * 25;
     padding-top: $line-height * 4;
 

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -745,8 +745,12 @@
     &.past-budgets {
       min-height: 0;
 
-      .button ~ .button {
-        margin-left: $line-height / 2;
+      .button {
+        margin-right: $line-height / 2;
+
+        ~ .button {
+          margin-right: $line-height / 2;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1411,6 +1411,11 @@
       background-repeat: no-repeat;
       background-size: cover;
     }
+
+    &.groups {
+      min-height: 0;
+      padding-top: 0;
+    }
   }
 }
 
@@ -1738,6 +1743,7 @@
     border-radius: rem-calc(3);
     display: inline-block;
     margin-bottom: $line-height / 2;
+    position: relative;
 
     a {
       display: block;
@@ -1757,6 +1763,24 @@
       color: $text;
       display: block;
       font-size: $small-font-size;
+    }
+  }
+
+  .is-active a {
+    background: #f9f9f9;
+    border-radius: rem-calc(3);
+    color: $budget;
+    font-weight: bold;
+
+    &::after {
+      content: "\f058";
+      font-family: "Font Awesome 5 Free";
+      font-size: $small-font-size;
+      font-weight: bold;
+      line-height: $line-height;
+      position: absolute;
+      top: 0;
+      right: 6px;
     }
   }
 }
@@ -1919,34 +1943,6 @@
       .remove-investment-project .icon-x {
         color: #fff;
       }
-    }
-  }
-}
-
-.select-district a {
-  display: inline-block;
-  margin: $line-height / 4 0;
-  padding: $line-height / 4;
-}
-
-.select-district .is-active a {
-  background: #f9f9f9;
-  border-radius: rem-calc(3);
-  color: $budget;
-  font-weight: bold;
-  padding: $line-height / 4;
-
-  &::after {
-    content: "\56";
-    font-family: "icons";
-    font-size: $small-font-size;
-    font-weight: normal;
-    line-height: $line-height;
-    padding-left: rem-calc(3);
-    vertical-align: baseline;
-
-    &:hover {
-      text-decoration: none;
     }
   }
 }

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1671,9 +1671,6 @@
 
   .budget-prev-phase-disabled,
   .budget-next-phase-disabled {
-    display: block;
-    height: rem-calc(36);
-    width: rem-calc(36);
 
     &::before {
       background: none;

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -850,10 +850,6 @@
   display: flex;
   flex-wrap: wrap;
 
-  h2 {
-    font-size: $base-font-size;
-  }
-
   .column {
     margin-bottom: $line-height / 2;
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,10 +110,10 @@ class ApplicationController < ActionController::Base
     end
 
     def set_default_budget_filter
-      if @budget&.balloting? || @budget&.publishing_prices?
-        params[:filter] ||= "selected"
-      elsif @budget&.finished?
+      if @budget&.finished?
         params[:filter] ||= "winners"
+      elsif @budget&.publishing_prices_or_later?
+        params[:filter] ||= "selected"
       end
     end
 

--- a/app/controllers/budgets/groups_controller.rb
+++ b/app/controllers/budgets/groups_controller.rb
@@ -1,15 +1,12 @@
 module Budgets
   class GroupsController < ApplicationController
     before_action :load_budget
-    before_action :load_group
+    before_action :load_group, only: :show
     load_and_authorize_resource :budget
     load_and_authorize_resource :group, class: "Budget::Group"
 
-    before_action :set_default_budget_filter, only: :show
-    has_filters %w[not_unfeasible feasible unfeasible unselected selected winners], only: [:show]
-
-    def show
-    end
+    before_action :set_default_budget_filter, only: [:index, :show]
+    has_filters %w[not_unfeasible feasible unfeasible unselected selected winners], only: [:index, :show]
 
     private
 

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -4,10 +4,13 @@ class BudgetsController < ApplicationController
   feature_flag :budgets
 
   before_action :load_budget, only: :show
+  before_action :load_current_budget, only: :index
+  before_action :load_map_locations, only: [:index, :show]
+  before_action :load_banners, only: [:index, :show]
   before_action :load_investments, only: [:index, :show]
   load_and_authorize_resource
-  before_action :set_default_budget_filter, only: :show
-  has_filters %w[not_unfeasible feasible unfeasible unselected selected winners], only: :show
+  before_action :set_default_budget_filter, only: [:index, :show]
+  has_filters %w[not_unfeasible feasible unfeasible unselected selected winners], only: [:index, :show]
 
   respond_to :html, :js
 
@@ -17,14 +20,24 @@ class BudgetsController < ApplicationController
 
   def index
     @finished_budgets = @budgets.finished.order(created_at: :desc)
-    @budgets_coordinates = current_budget_map_locations
-    @banners = Banner.in_section("budgets").with_active
   end
 
   private
 
     def load_budget
       @budget = Budget.find_by_slug_or_id! params[:id]
+    end
+
+    def load_current_budget
+      @budget = current_budget
+    end
+
+    def load_map_locations
+      @budgets_coordinates = budget_map_locations(@budget)
+    end
+
+    def load_banners
+      @banners = Banner.in_section("budgets").with_active
     end
 
     def load_investments

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -1,8 +1,4 @@
 module BudgetsHelper
-  def show_links_to_budget_investments(budget)
-    ["balloting", "reviewing_ballots", "finished"].include? budget.phase
-  end
-
   def heading_name_and_price_html(heading, budget)
     content_tag :div do
       concat(heading.name + " ")
@@ -65,13 +61,13 @@ module BudgetsHelper
     !budget.drafting? || current_user&.administrator?
   end
 
-  def current_budget_map_locations
-    return unless current_budget.present?
+  def budget_map_locations(budget)
+    return unless budget.present?
 
-    if current_budget.publishing_prices_or_later? && current_budget.investments.selected.any?
-      investments = current_budget.investments.selected
+    if budget.publishing_prices_or_later? && budget.investments.selected.any?
+      investments = budget.investments.selected
     else
-      investments = current_budget.investments
+      investments = budget.investments
     end
 
     MapLocation.where(investment_id: investments).map(&:json_data)

--- a/app/views/budgets/_all_investments_link.html.erb
+++ b/app/views/budgets/_all_investments_link.html.erb
@@ -1,0 +1,13 @@
+<div class="row margin-top">
+  <div class="small-12 medium-6 large-4 small-centered column margin-top">
+    <% if budget.single_heading? %>
+      <%= link_to t("budgets.show.see_all_investments"),
+                  budget_investments_path(budget, heading_id: budget.headings.first.id, filter: @current_filter),
+                  class: "button expanded" %>
+    <% else %>
+      <%= link_to t("budgets.show.see_all_investments"),
+                  budget_groups_path(budget, filter: @current_filter),
+                  class: "button expanded" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/budgets/_budget.html.erb
+++ b/app/views/budgets/_budget.html.erb
@@ -1,0 +1,84 @@
+<% if budget.image.present? %>
+<div id="budget_heading"
+     class="expanded budget with-background-image no-margin-top"
+     style="background-image: url(<%= asset_url budget.image.attachment.url(:large) %>);">
+<% else %>
+<div id="budget_heading" class="expanded budget no-margin-top">
+<% end %>
+  <div class="row">
+    <div class="small-12 column text-center">
+      <span class="budget-title"><%= t("budgets.index.title") %></span>
+      <h1><%= budget.name %></h1>
+
+      <% if budget.main_button_text.present? && budget.main_button_url.present? %>
+        <%= link_to budget.main_button_text, budget.main_button_url, class: "button large" %>
+      <% end %>
+
+      <p>
+        <%= link_to t("budgets.index.section_header.help"), "#section_help" %>
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="row budget-subheader">
+  <div class="small-12 medium-8 column padding">
+    <span class="current-phase"><strong><%= t("budgets.show.phase") %></strong></span>
+    <h2><%= t("budgets.phase.#{budget.phase}") %></h2>
+  </div>
+
+  <div class="small-12 medium-4 column">
+    <% if budget.accepting? %>
+      <% if current_user %>
+        <% if current_user.level_two_or_three_verified? %>
+          <div class="text-right">
+            <%= link_to t("budgets.investments.index.sidebar.create"),
+                        new_budget_investment_path(budget),
+                        class: "button margin-top" %>
+          </div>
+        <% else %>
+          <div class="callout warning margin-top">
+            <%= sanitize(t("budgets.investments.index.sidebar.verified_only", verify: link_to_verify_account)) %>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="callout primary margin-top">
+          <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
+                         sign_in: link_to_signin,
+                         sign_up: link_to_signup)) %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <% if can?(:read_results, budget) %>
+      <div class="text-right">
+        <%= link_to t("budgets.show.see_results"),
+                    budget_results_path(budget, heading_id: budget.headings.first),
+                    class: "button expanded" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<%= render "phases", budget: budget %>
+
+<div id="budget_info" class="budget-info">
+  <div class="row margin-top">
+    <div class="small-12 column">
+      <% if budget.single_heading? %>
+        <%= render "single_heading", budget: budget %>
+      <% else %>
+        <%= render "groups_and_headings", budget: budget %>
+      <% end %>
+
+      <% unless budget.informing? %>
+        <div class="map inline">
+          <h3><%= t("budgets.index.map") %></h3>
+          <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<%= render "investments_list", budget: budget %>

--- a/app/views/budgets/_budget.html.erb
+++ b/app/views/budgets/_budget.html.erb
@@ -73,7 +73,7 @@
 
       <% unless budget.informing? %>
         <div class="map inline">
-          <h3><%= t("budgets.index.map") %></h3>
+          <h2><%= t("budgets.index.map") %></h2>
           <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
         </div>
       <% end %>

--- a/app/views/budgets/_finished.html.erb
+++ b/app/views/budgets/_finished.html.erb
@@ -1,30 +1,22 @@
 <div class="row margin-top">
-  <div class="small-12 medium-9 column">
+  <div class="small-12 column">
     <h2><%= t("budgets.index.finished_budgets") %></h2>
 
     <div id="finished_budgets">
       <% budgets.each do |budget| %>
         <div class="budget-investment clear">
           <div class="panel past-budgets">
-            <div class="row" data-equalizer data-equalizer-on="medium">
-              <div class="small-12 medium-6 column table" data-equalizer-watch>
-                <div class="table-cell align-middle">
-                  <h3><%= budget.name %></h3>
-                </div>
+            <div class="row">
+              <div class="small-12 medium-6 large-9 column">
+                <h3><%= budget.name %></h3>
               </div>
 
-              <div class="small-12 medium-6 column table" data-equalizer-watch>
-                <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
-                  <% if can?(:read_results, budget) %>
-                    <%= link_to t("budgets.index.see_results"),
-                                budget_results_path(budget),
-                                class: "button" %>
-                  <% end %>
+              <div id="budget_<%= budget.id %>_results" class="float-right">
+                <% if can?(:read_results, budget) %>
+                  <%= link_to t("budgets.index.see_results"), budget_results_path(budget), class: "button" %>
+                <% end %>
 
-                  <%= link_to t("budgets.index.milestones"),
-                              budget_executions_path(budget),
-                              class: "button" %>
-                </div>
+                <%= link_to t("budgets.index.milestones"), budget_executions_path(budget), class: "button" %>
               </div>
             </div>
           </div>

--- a/app/views/budgets/_finished.html.erb
+++ b/app/views/budgets/_finished.html.erb
@@ -2,7 +2,7 @@
   <div class="small-12 medium-9 column">
     <h2><%= t("budgets.index.finished_budgets") %></h2>
 
-    <div id="finished_budgets" class="budget-investments-list">
+    <div id="finished_budgets">
       <% budgets.each do |budget| %>
         <div class="budget-investment clear">
           <div class="panel past-budgets">

--- a/app/views/budgets/_footer.html.erb
+++ b/app/views/budgets/_footer.html.erb
@@ -1,0 +1,10 @@
+<div class="row">
+  <div class="small-12 column">
+    <div id="section_help" class="margin" data-magellan-target="section_help">
+      <p class="lead">
+        <strong><%= t("budgets.index.section_footer.title") %></strong>
+      </p>
+      <p><%= t("budgets.index.section_footer.description") %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/budgets/_groups_and_headings.html.erb
+++ b/app/views/budgets/_groups_and_headings.html.erb
@@ -1,17 +1,16 @@
 <div id="groups_and_headings" class="groups-and-headings">
-  <% current_budget.groups.each do |group| %>
+  <% budget.groups.each do |group| %>
     <h2 id="<%= group.name.parameterize %>"><%= group.name %></h2>
     <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
       <% group.headings.sort_by_name.each do |heading| %>
         <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
-          <% unless current_budget.informing? || current_budget.finished? %>
-            <%= link_to budget_investments_path(current_budget.id,
-                                                heading_id: heading.id) do %>
-              <%= heading_name_and_price_html(heading, current_budget) %>
+          <% unless budget.informing? || budget.finished? %>
+            <%= link_to budget_investments_path(budget.id, heading_id: heading.id) do %>
+              <%= heading_name_and_price_html(heading, budget) %>
             <% end %>
           <% else %>
             <div class="heading-name">
-              <%= heading_name_and_price_html(heading, current_budget) %>
+              <%= heading_name_and_price_html(heading, budget) %>
             </div>
           <% end %>
         </li>

--- a/app/views/budgets/_investments_list.html.erb
+++ b/app/views/budgets/_investments_list.html.erb
@@ -12,12 +12,8 @@
       <% end %>
     </div>
   </div>
+<% end %>
 
-  <div class="row margin-top">
-    <div class="small-12 medium-6 large-4 small-centered column margin-top">
-      <%= link_to t("budgets.show.see_all_investments"),
-                  budget_investments_path(@budget, heading_id: @budget.headings.first.id),
-                  class: "button expanded" %>
-    </div>
-  </div>
+<% unless budget.informing? %>
+  <%= render "all_investments_link", budget: budget %>
 <% end %>

--- a/app/views/budgets/_phases.html.erb
+++ b/app/views/budgets/_phases.html.erb
@@ -3,7 +3,7 @@
     <div class="small-12 column">
       <h2 class="text-center"><%= t("budgets.index.all_phases") %></h2>
 
-      <ul class="tabs" data-tabs id="budget_phases_tabs" data-deep-link="true" data-deep-link-smudge="true">
+      <ul class="tabs" data-tabs id="budget_phases_tabs" data-deep-link="true">
         <% budget.published_phases.each_with_index do |phase, index| %>
           <li class="tabs-title <%= "is-active" if phase == budget.current_phase %>">
             <a href="#<%= index + 1 %>-<%= budget_phase_name(phase).parameterize %>"

--- a/app/views/budgets/_phases.html.erb
+++ b/app/views/budgets/_phases.html.erb
@@ -4,11 +4,11 @@
       <h2 class="text-center"><%= t("budgets.index.all_phases") %></h2>
 
       <ul class="tabs" data-tabs id="budget_phases_tabs" data-deep-link="true" data-deep-link-smudge="true">
-        <% current_budget.published_phases.each_with_index do |phase, index| %>
-          <li class="tabs-title <%= "is-active" if phase == current_budget.current_phase %>">
+        <% budget.published_phases.each_with_index do |phase, index| %>
+          <li class="tabs-title <%= "is-active" if phase == budget.current_phase %>">
             <a href="#<%= index + 1 %>-<%= budget_phase_name(phase).parameterize %>"
-               class="<%= "current-phase" if phase == current_budget.current_phase %>">
-              <% if phase == current_budget.current_phase %>
+               class="<%= "current-phase" if phase == budget.current_phase %>">
+              <% if phase == budget.current_phase %>
                 <span class="current-phase-timeline"><%= t("budgets.index.current_phase") %></span>
               <% end %>
 
@@ -20,9 +20,9 @@
       </ul>
 
       <div class="tabs-content" data-tabs-content="budget_phases_tabs">
-        <% enabled_phases = current_budget.published_phases.to_a %>
+        <% enabled_phases = budget.published_phases.to_a %>
         <% enabled_phases.each_with_index do |phase, index| %>
-          <div class="tabs-panel <%= "is-active" if phase == current_budget.current_phase %>"
+          <div class="tabs-panel <%= "is-active" if phase == budget.current_phase %>"
                id="<%= index + 1 %>-<%= budget_phase_name(phase).parameterize %>">
 
             <% if enabled_phases.first == phase %>

--- a/app/views/budgets/_single_heading.html.erb
+++ b/app/views/budgets/_single_heading.html.erb
@@ -1,8 +1,5 @@
 <div class="single-heading">
-  <% current_budget.groups.each do |group| %>
-    <% group.headings.sort_by_name.each do |heading| %>
-      <h2><%= heading.name %></h2>
-      <p class="heading-amount"><%= current_budget.formatted_heading_price(heading) %></p>
-    <% end %>
-  <% end %>
+  <% heading = budget.headings.first %>
+  <h2><%= heading.name %></h2>
+  <p class="heading-amount"><%= budget.formatted_heading_price(heading) %></p>
 </div>

--- a/app/views/budgets/_title.html.erb
+++ b/app/views/budgets/_title.html.erb
@@ -1,0 +1,1 @@
+<% provide :title do %><%= t("budgets.index.title") %><% end %>

--- a/app/views/budgets/_title.html.erb
+++ b/app/views/budgets/_title.html.erb
@@ -1,1 +1,5 @@
-<% provide :title do %><%= t("budgets.index.title") %><% end %>
+<% if budget.present? %>
+  <% provide :title do %><%= budget.name %><% end %>
+<% else %>
+  <% provide :title do %><%= t("budgets.index.title") %><% end %>
+<% end %>

--- a/app/views/budgets/groups/index.html.erb
+++ b/app/views/budgets/groups/index.html.erb
@@ -1,0 +1,72 @@
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: budget_groups_url(filter: @current_filter) %>
+<% end %>
+
+<div class="expanded budget no-margin-top">
+  <div class="row">
+    <div class="small-12 medium-9 column padding">
+      <%= back_link_to budgets_path %>
+      <h2><%= t("budgets.groups.show.title") %></h2>
+    </div>
+  </div>
+</div>
+
+<% if @current_filter == "unfeasible" %>
+  <div class="row margin-top">
+    <div class="small-12 column">
+      <h3><%= t("budgets.groups.show.unfeasible_title") %></h3>
+    </div>
+  </div>
+<% elsif @current_filter == "unselected" %>
+  <div class="row margin-top">
+    <div class="small-12 column">
+      <h3><%= t("budgets.groups.show.unselected_title") %></h3>
+    </div>
+  </div>
+<% end %>
+
+<div class="row margin">
+  <div id="headings" class="small-12 medium-7 column select-district">
+    <% @budget.groups.sort_by_name.each do |group| %>
+      <h3><%= group.name %></h3>
+      <div class="row">
+        <% group.headings.sort_by_name.each_slice(7) do |slice| %>
+          <div class="small-6 medium-4 column end">
+            <% slice.each do |heading| %>
+              <span id="<%= dom_id(heading) %>"
+                    class="<%= css_for_ballot_heading(heading) %>">
+                <%= link_to heading.name,
+                            budget_investments_path(heading_id: heading.id, filter: @current_filter),
+                            data: { no_turbolink: true } %><br>
+              </span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<% if @budget.balloting_or_later? %>
+  <% unless @current_filter == "unfeasible" %>
+    <div class="row">
+      <div class="small-12 column">
+        <small>
+          <%= link_to t("budgets.groups.show.unfeasible"),
+                      budget_groups_path(@budget, filter: "unfeasible") %>
+        </small>
+      </div>
+    </div>
+  <% end %>
+
+  <% unless @current_filter == "unselected" %>
+    <div class="row">
+      <div class="small-12 column">
+        <small>
+          <%= link_to t("budgets.groups.show.unselected"),
+                      budget_groups_path(@budget, filter: "unselected") %>
+        </small>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/budgets/groups/index.html.erb
+++ b/app/views/budgets/groups/index.html.erb
@@ -2,71 +2,33 @@
   <%= render "shared/canonical", href: budget_groups_url(filter: @current_filter) %>
 <% end %>
 
-<div class="expanded budget no-margin-top">
+<div class="expanded budget no-margin-top groups">
   <div class="row">
-    <div class="small-12 medium-9 column padding">
-      <%= back_link_to budgets_path %>
-      <h2><%= t("budgets.groups.show.title") %></h2>
+    <div class="small-12 column padding">
+      <%= back_link_to budget_path(@budget) %>
+      <h2>
+        <%= t("budgets.groups.show.title") %>
+      </h2>
     </div>
   </div>
 </div>
 
-<% if @current_filter == "unfeasible" %>
-  <div class="row margin-top">
-    <div class="small-12 column">
-      <h3><%= t("budgets.groups.show.unfeasible_title") %></h3>
-    </div>
-  </div>
-<% elsif @current_filter == "unselected" %>
-  <div class="row margin-top">
-    <div class="small-12 column">
-      <h3><%= t("budgets.groups.show.unselected_title") %></h3>
-    </div>
-  </div>
-<% end %>
-
 <div class="row margin">
-  <div id="headings" class="small-12 medium-7 column select-district">
+  <div class="small-12 column groups-and-headings">
     <% @budget.groups.sort_by_name.each do |group| %>
       <h3><%= group.name %></h3>
-      <div class="row">
-        <% group.headings.sort_by_name.each_slice(7) do |slice| %>
-          <div class="small-6 medium-4 column end">
-            <% slice.each do |heading| %>
-              <span id="<%= dom_id(heading) %>"
-                    class="<%= css_for_ballot_heading(heading) %>">
-                <%= link_to heading.name,
-                            budget_investments_path(heading_id: heading.id, filter: @current_filter),
-                            data: { no_turbolink: true } %><br>
-              </span>
-            <% end %>
-          </div>
+      <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
+        <% group.headings.sort_by_name.each do |heading| %>
+          <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
+            <span id="<%= dom_id(heading) %>"
+                  class="<%= css_for_ballot_heading(heading) %>">
+              <%= link_to budget_investments_path(@budget.id, heading_id: heading.id) do %>
+                <%= heading_name_and_price_html(heading, @budget) %>
+              <% end %>
+            </span>
+          </li>
         <% end %>
-      </div>
+      </ul>
     <% end %>
   </div>
 </div>
-
-<% if @budget.balloting_or_later? %>
-  <% unless @current_filter == "unfeasible" %>
-    <div class="row">
-      <div class="small-12 column">
-        <small>
-          <%= link_to t("budgets.groups.show.unfeasible"),
-                      budget_groups_path(@budget, filter: "unfeasible") %>
-        </small>
-      </div>
-    </div>
-  <% end %>
-
-  <% unless @current_filter == "unselected" %>
-    <div class="row">
-      <div class="small-12 column">
-        <small>
-          <%= link_to t("budgets.groups.show.unselected"),
-                      budget_groups_path(@budget, filter: "unselected") %>
-        </small>
-      </div>
-    </div>
-  <% end %>
-<% end %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -137,13 +137,4 @@
   </div>
 <% end %>
 
-<div class="row">
-  <div class="small-12 column">
-    <div id="section_help" class="margin" data-magellan-target="section_help">
-      <p class="lead">
-        <strong><%= t("budgets.index.section_footer.title") %></strong>
-      </p>
-      <p><%= t("budgets.index.section_footer.description") %></p>
-    </div>
-  </div>
-</div>
+<%= render "footer" %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -2,123 +2,18 @@
   <%= render "shared/banner" %>
 <% end %>
 
-<%= render "title" %>
+<%= render "title", budget: @budget %>
 
 <% content_for :canonical do %>
   <%= render "shared/canonical", href: budgets_url %>
 <% end %>
 
-<% if current_budget.present? %>
-  <% if current_budget.image.present? %>
-    <div id="budget_heading"
-         class="expanded budget with-background-image no-margin-top"
-         style="background-image: url(<%= asset_url current_budget.image.attachment.url(:large) %>);">
-  <% else %>
-    <div id="budget_heading" class="expanded budget no-margin-top">
+<% if @budget.present? %>
+  <%= render "budget", budget: @budget %>
+
+  <% if @finished_budgets.present? %>
+    <%= render "finished", budgets: @finished_budgets %>
   <% end %>
-    <div class="row">
-      <div class="small-12 column text-center">
-          <span class="budget-title"><%= t("budgets.index.title") %></span>
-          <h1><%= current_budget.name %></h1>
-
-          <% if current_budget.main_button_text.present? && current_budget.main_button_url.present? %>
-            <%= link_to current_budget.main_button_text, current_budget.main_button_url,
-                        class: "button large" %>
-          <% end %>
-
-          <p>
-            <%= link_to t("budgets.index.section_header.help"), "#section_help" %>
-          </p>
-        </div>
-      </div>
-    </div>
-    <div class="row budget-subheader">
-      <div class="small-12 medium-8 column padding">
-        <span class="current-phase"><strong><%= t("budgets.show.phase") %></strong></span>
-        <h2><%= t("budgets.phase.#{current_budget.phase}") %></h2>
-      </div>
-
-      <div class="small-12 medium-4 column">
-        <% if current_budget.accepting? %>
-          <% if current_user %>
-            <% if current_user.level_two_or_three_verified? %>
-              <div class="text-right">
-                <%= link_to t("budgets.investments.index.sidebar.create"),
-                            new_budget_investment_path(current_budget),
-                            class: "button margin-top" %>
-              </div>
-            <% else %>
-              <div class="callout warning margin-top">
-                <%= sanitize(t("budgets.investments.index.sidebar.verified_only",
-                      verify: link_to_verify_account)) %>
-              </div>
-            <% end %>
-          <% else %>
-            <div class="callout primary margin-top">
-              <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
-                    sign_in: link_to_signin, sign_up: link_to_signup)) %>
-            </div>
-          <% end %>
-        <% end %>
-
-        <% if can?(:read_results, current_budget) %>
-          <div class="text-right">
-            <%= link_to t("budgets.show.see_results"),
-                        budget_results_path(current_budget, heading_id: current_budget.headings.first),
-                        class: "button expanded" %>
-          </div>
-        <% end %>
-    </div>
-  </div>
-
-  <%= render "phases", budget: current_budget %>
-
-  <div id="budget_info" class="budget-info">
-    <div class="row margin-top">
-      <div class="small-12 column">
-
-        <% if current_budget.single_heading? %>
-          <%= render "single_heading" %>
-        <% else %>
-          <%= render "groups_and_headings" %>
-        <% end %>
-
-        <% unless current_budget.informing? %>
-          <div class="map inline">
-            <h3><%= t("budgets.index.map") %></h3>
-            <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
-          </div>
-
-          <ul class="no-bullet margin-top">
-            <% show_links = show_links_to_budget_investments(current_budget) %>
-            <% if show_links %>
-              <li>
-                <%= link_to budget_path(current_budget) do %>
-                  <small><%= t("budgets.index.investment_proyects") %></small>
-                <% end %>
-              </li>
-            <% end %>
-            <li>
-              <%= link_to budget_path(current_budget, filter: "unfeasible") do %>
-                <small><%= t("budgets.index.unfeasible_investment_proyects") %></small>
-              <% end %>
-            </li>
-            <% if show_links %>
-              <li>
-                <%= link_to budget_path(current_budget, filter: "unselected") do %>
-                  <small><%= t("budgets.index.not_selected_investment_proyects") %></small>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-      </div>
-    </div>
-
-    <% if @finished_budgets.present? %>
-      <%= render "finished", budgets: @finished_budgets %>
-    <% end %>
-  </div>
 <% else %>
   <div class="expanded budget no-margin-top margin-bottom">
     <div class="row">

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -2,7 +2,7 @@
   <%= render "shared/banner" %>
 <% end %>
 
-<% provide :title do %><%= t("budgets.index.title") %><% end %>
+<%= render "title" %>
 
 <% content_for :canonical do %>
   <%= render "shared/canonical", href: budgets_url %>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -59,17 +59,7 @@
                                   heading_price: @heading.price,
                                   investments: @investments.incompatible %>
     <% end %>
-
-    <p>
-      <%= link_to budget_path(@budget) do %>
-        <small><%= t("budgets.results.investment_proyects") %></small>
-      <% end %><br>
-      <%= link_to budget_path(@budget, filter: "unfeasible") do %>
-        <small><%= t("budgets.results.unfeasible_investment_proyects") %></small>
-      <% end %><br>
-      <%= link_to budget_path(@budget, filter: "unselected") do %>
-        <small><%= t("budgets.results.not_selected_investment_proyects") %></small>
-      <% end %>
-    </p>
   </div>
+
+  <%= render "budgets/all_investments_link", budget: @budget %>
 </div>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -1,106 +1,13 @@
+<% if has_banners? %>
+  <%= render "shared/banner" %>
+<% end %>
+
+<%= render "title", budget: @budget %>
+
 <% content_for :canonical do %>
   <%= render "shared/canonical", href: budget_url(@budget, filter: @current_filter) %>
 <% end %>
 
-<div class="expanded budget no-margin-top">
-  <div class="row" data-equalizer data-equalizer-on="medium">
-    <div class="small-12 medium-9 column padding" data-equalizer-watch>
-      <%= back_link_to budgets_path %>
+<%= render "budget", budget: @budget %>
 
-      <h1><%= @budget.name %></h1>
-
-      <%= auto_link_already_sanitized_html wysiwyg(@budget.description) %>
-    </div>
-    <div class="small-12 medium-3 column info padding" data-equalizer-watch>
-      <p>
-        <strong><%= t("budgets.show.phase") %></strong>
-      </p>
-      <h2><%= t("budgets.phase.#{@budget.phase}") %></h2>
-
-      <% if @budget.accepting? %>
-        <% if current_user %>
-          <% if current_user.level_two_or_three_verified? %>
-            <%= link_to t("budgets.investments.index.sidebar.create"), new_budget_investment_path(@budget), class: "button margin-top expanded" %>
-          <% else %>
-            <div class="callout warning margin-top">
-              <%= sanitize(t("budgets.investments.index.sidebar.verified_only",
-                  verify: link_to_verify_account)) %>
-            </div>
-          <% end %>
-        <% else %>
-          <div class="callout primary margin-top">
-            <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
-                  sign_in: link_to_signin, sign_up: link_to_signup)) %>
-          </div>
-        <% end %>
-      <% end %>
-
-      <% if can?(:read_results, @budget) %>
-        <%= link_to t("budgets.show.see_results"),
-                    budget_results_path(@budget),
-                    class: "button margin-top expanded" %>
-      <% end %>
-    </div>
-  </div>
-</div>
-
-<div class="row margin">
-  <div class="small-12 medium-9 column">
-    <% if @current_filter == "unfeasible" %>
-      <h3 class="margin-bottom"><%= t("budgets.show.unfeasible_title") %></h3>
-    <% elsif @current_filter == "unselected" %>
-      <h3 class="margin-bottom"><%= t("budgets.show.unselected_title") %></h3>
-    <% end %>
-    <table class="table-fixed">
-      <thead>
-        <th><%= t("budgets.show.group") %></th>
-      </thead>
-      <tbody>
-        <% @budget.groups.each do |group| %>
-          <tr>
-            <td>
-              <% if group.single_heading_group? %>
-                <%= link_to group.name,
-                            budget_investments_path(@budget,
-                              heading_id: group.headings.first.id,
-                              filter: @current_filter),
-                            data: { no_turbolink: true } %>
-              <% else %>
-                <%= link_to group.name,
-                            budget_group_path(@budget, group,
-                              filter: @current_filter) %>
-              <% end %>
-              <br>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
-
-<% if @budget.balloting_or_later? %>
-  <% unless @current_filter == "unfeasible" %>
-    <div class="row">
-      <div class="small-12 column">
-        <small>
-          <%= link_to t("budgets.show.unfeasible"),
-                      budget_path(@budget, filter: "unfeasible") %>
-        </small>
-      </div>
-    </div>
-  <% end %>
-
-  <% unless @current_filter == "unselected" %>
-    <div class="row">
-      <div class="small-12 column">
-        <small>
-          <%= link_to t("budgets.show.unselected"),
-                      budget_path(@budget, filter: "unselected") %>
-        </small>
-      </div>
-    </div>
-  <% end %>
-<% end %>
-
-<%= render "investments_list" %>
+<%= render "footer" %>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -25,7 +25,7 @@ en:
         casted_offline: You have already participated offline
     groups:
       show:
-        title: Select an option
+        title: Select a heading
         unfeasible_title: Unfeasible investments
         unfeasible: See unfeasible investments
         unselected_title: Investments not selected for balloting phase

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -48,7 +48,7 @@ en:
         icon_alt: Participatory budgets icon
         title: Participatory budgets
         help: Help with participatory budgets
-      all_phases: Budget investment's phases
+      all_phases: Participatory budgets phases
       next_phase: Next phase
       prev_phase: Previous phase
       current_phase: Current phase

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -53,9 +53,6 @@ en:
       prev_phase: Previous phase
       current_phase: Current phase
       map: Budget investments' proposals located geographically
-      investment_proyects: List of all investment projects
-      unfeasible_investment_proyects: List of all unfeasible investment projects
-      not_selected_investment_proyects: List of all investment projects not selected for balloting
       finished_budgets: Finished participatory budgets
       see_results: See results
       section_footer:
@@ -155,12 +152,7 @@ en:
       assigned: "You have assigned: "
       available: "Available budget: "
     show:
-      group: Group
       phase: Actual phase
-      unfeasible_title: Unfeasible investments
-      unfeasible: See unfeasible investments
-      unselected_title: Investments not selected for balloting phase
-      unselected: See investments not selected for balloting phase
       see_results: See results
       see_all_investments: "See all investments"
       investments_list: "List of investments"
@@ -178,9 +170,6 @@ en:
       discarded: "Discarded investment: "
       incompatibles: Incompatibles
       investment_title: Project title
-      investment_proyects: List of all investment projects
-      unfeasible_investment_proyects: List of all unfeasible investment projects
-      not_selected_investment_proyects: List of all investment projects not selected for balloting
     executions:
       link: "Milestones"
       page_title: "%{budget} - Milestones"

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -53,9 +53,6 @@ es:
       prev_phase: Fase anterior
       current_phase: Fase actual
       map: Proyectos localizables geográficamente
-      investment_proyects: Ver lista completa de proyectos de gasto
-      unfeasible_investment_proyects: Ver lista de proyectos de gasto inviables
-      not_selected_investment_proyects: Ver lista de proyectos de gasto no seleccionados para la votación final
       finished_budgets: Presupuestos participativos terminados
       see_results: Ver resultados
       section_footer:
@@ -155,12 +152,7 @@ es:
       assigned: "Has asignado: "
       available: "Presupuesto disponible: "
     show:
-      group: Grupo
       phase: Fase actual
-      unfeasible_title: Proyectos de gasto inviables
-      unfeasible: Ver los proyectos inviables
-      unselected_title: Proyectos no seleccionados para la votación final
-      unselected: Ver los proyectos no seleccionados para la votación final
       see_results: Ver resultados
       see_all_investments: "Ver todos los proyectos"
       investments_list: "Lista de proyectos"
@@ -178,9 +170,6 @@ es:
       discarded: "Proyecto de gasto descartado: "
       incompatibles: Incompatibles
       investment_title: Título del proyecto de gasto
-      investment_proyects: Ver lista completa de proyectos de gasto
-      unfeasible_investment_proyects: Ver lista de proyectos de gasto inviables
-      not_selected_investment_proyects: Ver lista de proyectos de gasto no seleccionados para la votación final
     executions:
       link: "Seguimiento"
       page_title: "%{budget} - Seguimiento de proyectos"

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -25,7 +25,7 @@ es:
         casted_offline: Ya has participado presencialmente
     groups:
       show:
-        title: Selecciona una opción
+        title: Selecciona una partida
         unfeasible_title: Proyectos de gasto inviables
         unfeasible: Ver proyectos inviables
         unselected_title: Proyectos no seleccionados para la votación final

--- a/config/routes/budget.rb
+++ b/config/routes/budget.rb
@@ -1,5 +1,5 @@
 resources :budgets, only: [:show, :index] do
-  resources :groups, controller: "budgets/groups", only: [:show]
+  resources :groups, controller: "budgets/groups", only: [:index, :show]
   resources :investments, controller: "budgets/investments" do
     member do
       post :vote

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -64,8 +64,8 @@ describe "Ballots" do
       scenario "Groups" do
         visit budget_path(budget)
 
-        expect(page).to have_link "City"
-        expect(page).to have_link "Districts"
+        expect(page).to have_content "City"
+        expect(page).to have_content "Districts"
       end
 
       scenario "Headings" do
@@ -75,14 +75,10 @@ describe "Ballots" do
         create(:budget_heading, group: districts, name: "District 2")
 
         visit budget_path(budget)
-        click_link "City"
+        click_link "See all investments"
 
         expect(page).to have_link "Investments Type1"
         expect(page).to have_link "Investments Type2"
-
-        visit budget_path(budget)
-        click_link "Districts"
-
         expect(page).to have_link "District 1"
         expect(page).to have_link "District 2"
       end
@@ -105,7 +101,7 @@ describe "Ballots" do
         end
 
         visit budget_path(budget)
-        click_link "City"
+        click_link "See all investments"
         click_link "Above the city"
 
         expect(page).to have_css(".budget-investment", count: 2)
@@ -113,8 +109,7 @@ describe "Ballots" do
         expect(page).to have_content "Observatory"
 
         visit budget_path(budget)
-
-        click_link "Districts"
+        click_link "See all investments"
         click_link "District 1"
 
         expect(page).to have_css(".budget-investment", count: 2)
@@ -122,21 +117,11 @@ describe "Ballots" do
         expect(page).to have_content "Zero-emission zone"
 
         visit budget_path(budget)
-        click_link "Districts"
+        click_link "See all investments"
         click_link "District 2"
 
         expect(page).to have_css(".budget-investment", count: 1)
         expect(page).to have_content "Climbing wall"
-      end
-
-      scenario "Redirect to first heading if there is only one" do
-        city_heading    = create(:budget_heading, group: city, name: "City")
-        city_investment = create(:budget_investment, :selected, heading: city_heading)
-
-        visit budget_path(budget)
-        click_link "City"
-
-        expect(page).to have_content city_investment.title
       end
     end
 
@@ -146,7 +131,7 @@ describe "Ballots" do
         create(:budget_investment, :selected, heading: new_york, price: 20000, title: "Paint cabs black")
 
         visit budget_path(budget)
-        click_link "States"
+        click_link "See all investments"
         click_link "New York"
 
         add_to_ballot("Bring back King Kong")
@@ -176,7 +161,7 @@ describe "Ballots" do
         investment = create(:budget_investment, :selected, heading: new_york, price: 10000, balloters: [user])
 
         visit budget_path(budget)
-        click_link "States"
+        click_link "See all investments"
         click_link "New York"
 
         expect(page).to have_content investment.title
@@ -207,7 +192,7 @@ describe "Ballots" do
         create(:budget_investment, :selected, heading: new_york, price: 10000, title: "More bridges")
 
         visit budget_path(budget)
-        click_link "States"
+        click_link "See all investments"
         click_link "New York"
 
         within("#sidebar") do
@@ -244,7 +229,8 @@ describe "Ballots" do
         create(:budget_investment, :selected, heading: district_heading2, price: 30000, title: "Expensive")
 
         visit budget_path(budget)
-        click_link "City"
+        click_link "See all investments"
+        click_link "All city"
 
         add_to_ballot("Cheap")
 
@@ -257,7 +243,7 @@ describe "Ballots" do
         end
 
         visit budget_path(budget)
-        click_link "Districts"
+        click_link "See all investments"
         click_link "District 1"
 
         expect(page).to have_css("#amount-spent", text: "€0")
@@ -277,7 +263,8 @@ describe "Ballots" do
         end
 
         visit budget_path(budget)
-        click_link "City"
+        click_link "See all investments"
+        click_link "All city"
 
         expect(page).to have_css("#amount-spent",     text: "€10,000")
         expect(page).to have_css("#amount-available", text: "€9,990,000")
@@ -291,7 +278,7 @@ describe "Ballots" do
         end
 
         visit budget_path(budget)
-        click_link "Districts"
+        click_link "See all investments"
         click_link "District 2"
 
         expect(page).to have_content("You have active votes in another heading: District 1")
@@ -318,13 +305,13 @@ describe "Ballots" do
       create(:budget_investment, :selected, heading: california, title: "Green beach")
 
       visit budget_path(budget)
-      click_link "States"
+      click_link "See all investments"
       click_link "California"
 
       add_to_ballot("Green beach")
 
       visit budget_path(budget)
-      click_link "States"
+      click_link "See all investments"
 
       expect(page).to have_content "California"
       expect(page).to have_css("#budget_heading_#{california.id}.is-active")
@@ -346,7 +333,7 @@ describe "Ballots" do
       add_to_ballot("Avengers Tower")
 
       visit budget_path(budget)
-      click_link "States"
+      click_link "See all investments"
       expect(page).to have_css("#budget_heading_#{new_york.id}.is-active")
       expect(page).not_to have_css("#budget_heading_#{california.id}.is-active")
     end
@@ -363,16 +350,6 @@ describe "Ballots" do
   end
 
   context "Showing the ballot" do
-    scenario "Do not display heading name if there is only one heading in the group (example: group city)" do
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
-      visit budget_path(budget)
-      click_link group.name
-      # No need to click on the heading name
-      expect(page).to have_content("Investment projects with scope: #{heading.name}")
-      expect(page).to have_current_path(budget_investments_path(budget), ignore_query: true)
-    end
-
     scenario "Displaying the correct group, heading, count & amount" do
       group1 = create(:budget_group, budget: budget)
       group2 = create(:budget_group, budget: budget)
@@ -540,8 +517,8 @@ describe "Ballots" do
 
       login_as(user)
       visit budget_path(budget)
-      click_link states.name
-      click_link new_york.name
+      click_link "See all investments"
+      click_link "New York"
 
       expect(page).not_to have_css("#budget_investment_#{investment.id}")
     end
@@ -551,8 +528,8 @@ describe "Ballots" do
 
       login_as(user)
       visit budget_path(budget)
-      click_link states.name
-      click_link new_york.name
+      click_link "See all investments"
+      click_link "New York"
 
       within("#budget-investments") do
         expect(page).not_to have_css("div.ballot")
@@ -670,7 +647,7 @@ describe "Ballots" do
 
       login_as(user)
       visit budget_path(budget)
-      click_link "States"
+      click_link "See all investments"
       click_link "New York"
 
       new_york.update!(price: 10)

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -77,10 +77,10 @@ describe "Ballots" do
         visit budget_path(budget)
         click_link "See all investments"
 
-        expect(page).to have_link "Investments Type1"
-        expect(page).to have_link "Investments Type2"
-        expect(page).to have_link "District 1"
-        expect(page).to have_link "District 2"
+        expect(page).to have_content "Investments Type1"
+        expect(page).to have_content "Investments Type2"
+        expect(page).to have_link "District 1 €1,000,000"
+        expect(page).to have_link "District 2 €1,000,000"
       end
 
       scenario "Investments" do
@@ -102,7 +102,7 @@ describe "Ballots" do
 
         visit budget_path(budget)
         click_link "See all investments"
-        click_link "Above the city"
+        click_link "Above the city €1,000,000"
 
         expect(page).to have_css(".budget-investment", count: 2)
         expect(page).to have_content "Solar panels"
@@ -110,7 +110,7 @@ describe "Ballots" do
 
         visit budget_path(budget)
         click_link "See all investments"
-        click_link "District 1"
+        click_link "District 1 €1,000,000"
 
         expect(page).to have_css(".budget-investment", count: 2)
         expect(page).to have_content "New park"
@@ -118,7 +118,7 @@ describe "Ballots" do
 
         visit budget_path(budget)
         click_link "See all investments"
-        click_link "District 2"
+        click_link "District 2 €1,000,000"
 
         expect(page).to have_css(".budget-investment", count: 1)
         expect(page).to have_content "Climbing wall"
@@ -132,7 +132,7 @@ describe "Ballots" do
 
         visit budget_path(budget)
         click_link "See all investments"
-        click_link "New York"
+        click_link "New York €1,000,000"
 
         add_to_ballot("Bring back King Kong")
 
@@ -162,7 +162,7 @@ describe "Ballots" do
 
         visit budget_path(budget)
         click_link "See all investments"
-        click_link "New York"
+        click_link "New York €1,000,000"
 
         expect(page).to have_content investment.title
         expect(page).to have_css("#amount-spent", text: "€10,000")
@@ -193,7 +193,7 @@ describe "Ballots" do
 
         visit budget_path(budget)
         click_link "See all investments"
-        click_link "New York"
+        click_link "New York €1,000,000"
 
         within("#sidebar") do
           expect(page).to have_content "OpenStreetMap"
@@ -230,7 +230,7 @@ describe "Ballots" do
 
         visit budget_path(budget)
         click_link "See all investments"
-        click_link "All city"
+        click_link "All city €10,000,000"
 
         add_to_ballot("Cheap")
 
@@ -244,7 +244,7 @@ describe "Ballots" do
 
         visit budget_path(budget)
         click_link "See all investments"
-        click_link "District 1"
+        click_link "District 1 €1,000,000"
 
         expect(page).to have_css("#amount-spent", text: "€0")
         expect(page).to have_css("#amount-spent", text: "€1,000,000")
@@ -264,7 +264,7 @@ describe "Ballots" do
 
         visit budget_path(budget)
         click_link "See all investments"
-        click_link "All city"
+        click_link "All city €10,000,000"
 
         expect(page).to have_css("#amount-spent",     text: "€10,000")
         expect(page).to have_css("#amount-available", text: "€9,990,000")
@@ -279,7 +279,7 @@ describe "Ballots" do
 
         visit budget_path(budget)
         click_link "See all investments"
-        click_link "District 2"
+        click_link "District 2 €2,000,000"
 
         expect(page).to have_content("You have active votes in another heading: District 1")
       end
@@ -306,7 +306,7 @@ describe "Ballots" do
 
       visit budget_path(budget)
       click_link "See all investments"
-      click_link "California"
+      click_link "California €1,000"
 
       add_to_ballot("Green beach")
 
@@ -518,7 +518,7 @@ describe "Ballots" do
       login_as(user)
       visit budget_path(budget)
       click_link "See all investments"
-      click_link "New York"
+      click_link "New York €1,000,000"
 
       expect(page).not_to have_css("#budget_investment_#{investment.id}")
     end
@@ -529,7 +529,7 @@ describe "Ballots" do
       login_as(user)
       visit budget_path(budget)
       click_link "See all investments"
-      click_link "New York"
+      click_link "New York €1,000,000"
 
       within("#budget-investments") do
         expect(page).not_to have_css("div.ballot")
@@ -648,7 +648,7 @@ describe "Ballots" do
       login_as(user)
       visit budget_path(budget)
       click_link "See all investments"
-      click_link "New York"
+      click_link "New York €1,000,000"
 
       new_york.update!(price: 10)
 

--- a/spec/features/budgets/groups_spec.rb
+++ b/spec/features/budgets/groups_spec.rb
@@ -7,12 +7,12 @@ describe "Budget Groups" do
   context "Load" do
     scenario "finds group using budget slug and group slug" do
       visit budget_group_path("budget_slug", "group_slug")
-      expect(page).to have_content "Select an option"
+      expect(page).to have_content "Select a heading"
     end
 
     scenario "finds group using budget id and group id" do
       visit budget_group_path(budget, group)
-      expect(page).to have_content "Select an option"
+      expect(page).to have_content "Select a heading"
     end
 
     scenario "raises an error if budget slug is not found" do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1566,14 +1566,14 @@ describe "Budget Investments" do
       login_as(user)
       visit budget_path(budget)
       click_link "See all investments"
-      click_link "Global Heading"
+      click_link "Global Heading €1,000,000"
 
       add_to_ballot("World T-Shirt")
       add_to_ballot("Eco pens")
 
       visit budget_path(budget)
       click_link "See all investments"
-      click_link "Carabanchel"
+      click_link "Carabanchel €1,000,000"
 
       add_to_ballot("Fireworks")
       add_to_ballot("Bus pass")
@@ -1619,7 +1619,7 @@ describe "Budget Investments" do
       visit budget_path(budget)
 
       click_link "See all investments"
-      click_link "Heading 1"
+      click_link "Heading 1 €1,000,000"
 
       add_to_ballot("Zero-emission zone")
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -79,7 +79,7 @@ describe "Budget Investments" do
     unfeasible_investment = create(:budget_investment, :unfeasible, heading: heading)
 
     visit budget_path(budget)
-    click_link "Health"
+    click_link "See all investments"
 
     expect(page).to have_selector("#budget-investments .budget-investment", count: 3)
     investments.each do |investment|
@@ -97,7 +97,7 @@ describe "Budget Investments" do
                    create(:budget_investment, heading: heading)]
 
     visit budget_path(budget)
-    click_link "Health"
+    click_link "See all investments"
 
     click_button "View mode"
 
@@ -522,47 +522,6 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "by unfeasibilty link for group with one heading" do
-      budget.update!(phase: :balloting)
-      group   = create(:budget_group,   name: "All City", budget: budget)
-      heading = create(:budget_heading, name: "Madrid",   group: group)
-
-      visit budget_path(budget)
-      click_link "See unfeasible investments"
-
-      click_link "All City"
-
-      expected_path = budget_investments_path(budget, heading_id: heading.id, filter: "unfeasible")
-      expect(page).to have_current_path(expected_path)
-    end
-
-    scenario "by unfeasibilty link for group with many headings" do
-      budget.update!(phase: :balloting)
-      group = create(:budget_group, name: "Districts", budget: budget)
-
-      barajas = create(:budget_heading, name: "Barajas", group: group)
-      carabanchel = create(:budget_heading, name: "Carabanchel", group: group)
-
-      create(:budget_investment, :feasible, heading: barajas, title: "Terminal 5")
-      create(:budget_investment, :unfeasible, heading: barajas, title: "Seaport")
-      create(:budget_investment, :unfeasible, heading: carabanchel, title: "Airport")
-
-      visit budget_path(budget)
-
-      click_link "See unfeasible investments"
-
-      click_link "Districts"
-      click_link "Barajas"
-
-      within("#budget-investments") do
-        expect(page).to have_css(".budget-investment", count: 1)
-
-        expect(page).to have_content "Seaport"
-        expect(page).not_to have_content "Terminal 5"
-        expect(page).not_to have_content "Airport"
-      end
-    end
-
     context "Results Phase" do
       before { budget.update(phase: "finished", results_enabled: true) }
 
@@ -571,7 +530,7 @@ describe "Budget Investments" do
         investment2 = create(:budget_investment, :selected, heading: heading)
 
         visit budget_path(budget)
-        click_link "Health"
+        click_link "See all investments"
 
         within("#budget-investments") do
           expect(page).to have_css(".budget-investment", count: 1)
@@ -580,38 +539,7 @@ describe "Budget Investments" do
         end
 
         visit budget_results_path(budget)
-        click_link "List of all investment projects"
-        click_link "Health"
-
-        within("#budget-investments") do
-          expect(page).to have_css(".budget-investment", count: 1)
-          expect(page).to have_content(investment1.title)
-          expect(page).not_to have_content(investment2.title)
-        end
-      end
-
-      scenario "unfeasible", :js do
-        investment1 = create(:budget_investment, :unfeasible, :finished, heading: heading)
-        investment2 = create(:budget_investment, :feasible, heading: heading)
-
-        visit budget_results_path(budget)
-        click_link "List of all unfeasible investment projects"
-        click_link "Health"
-
-        within("#budget-investments") do
-          expect(page).to have_css(".budget-investment", count: 1)
-          expect(page).to have_content(investment1.title)
-          expect(page).not_to have_content(investment2.title)
-        end
-      end
-
-      scenario "unselected" do
-        investment1 = create(:budget_investment, :unselected, heading: heading)
-        investment2 = create(:budget_investment, :selected, heading: heading)
-
-        visit budget_results_path(budget)
-        click_link "List of all investment projects not selected for balloting"
-        click_link "Health"
+        click_link "See all investments"
 
         within("#budget-investments") do
           expect(page).to have_css(".budget-investment", count: 1)
@@ -1561,8 +1489,7 @@ describe "Budget Investments" do
 
       first(:link, "Participatory budgeting").click
 
-      click_link "List of all investment projects"
-      click_link "Health"
+      click_link "See all investments"
 
       within("#budget_investment_#{investment1.id}") do
         expect(page).to have_content investment1.title
@@ -1638,17 +1565,14 @@ describe "Budget Investments" do
 
       login_as(user)
       visit budget_path(budget)
-
-      click_link "Global Group"
-      # No need to click_link "Global Heading" because the link of a group with a single heading
-      # points to the list of investments directly
+      click_link "See all investments"
+      click_link "Global Heading"
 
       add_to_ballot("World T-Shirt")
       add_to_ballot("Eco pens")
 
       visit budget_path(budget)
-
-      click_link "Health"
+      click_link "See all investments"
       click_link "Carabanchel"
 
       add_to_ballot("Fireworks")
@@ -1682,7 +1606,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Highlight voted heading except with unfeasible filter", :js do
+    scenario "Highlight voted heading", :js do
       budget.update!(phase: "balloting")
       user = create(:user, :level_two)
 
@@ -1694,7 +1618,7 @@ describe "Budget Investments" do
       login_as(user)
       visit budget_path(budget)
 
-      click_link "Health"
+      click_link "See all investments"
       click_link "Heading 1"
 
       add_to_ballot("Zero-emission zone")
@@ -1704,16 +1628,6 @@ describe "Budget Investments" do
       expect(page).to have_css("#budget_heading_#{heading_1.id}.is-active")
       expect(page).to have_css("#budget_heading_#{heading_2.id}")
 
-      visit budget_group_path(budget, group)
-
-      click_link "See unfeasible investments"
-      click_link "Health"
-
-      within("#headings") do
-        expect(page).to have_css("#budget_heading_#{heading_1.id}")
-        expect(page).to have_css("#budget_heading_#{heading_2.id}")
-        expect(page).not_to have_css(".is-active")
-      end
     end
 
     scenario "Ballot is visible" do
@@ -1745,45 +1659,6 @@ describe "Budget Investments" do
         expect(page).not_to have_content(investment2.title)
         expect(page).not_to have_content(investment3.title)
         expect(page).not_to have_content(investment4.title)
-      end
-    end
-
-    scenario "Shows unselected link for group with one heading" do
-      group   = create(:budget_group,   name: "All City", budget: budget)
-      heading = create(:budget_heading, name: "Madrid",   group: group)
-
-      visit budget_path(budget)
-      click_link "See investments not selected for balloting phase"
-
-      click_link "All City"
-
-      expected_path = budget_investments_path(budget, heading_id: heading.id, filter: "unselected")
-      expect(page).to have_current_path(expected_path)
-    end
-
-    scenario "Shows unselected link for group with many headings" do
-      group = create(:budget_group, name: "Districts", budget: budget)
-
-      barajas = create(:budget_heading, name: "Barajas", group: group)
-      carabanchel = create(:budget_heading, name: "Carabanchel", group: group)
-
-      create(:budget_investment, :selected, heading: barajas, title: "Terminal 5")
-      create(:budget_investment, :unselected, heading: barajas, title: "Seaport")
-      create(:budget_investment, :unselected, heading: carabanchel, title: "Airport")
-
-      visit budget_path(budget)
-
-      click_link "See investments not selected for balloting phase"
-
-      click_link "Districts"
-      click_link "Barajas"
-
-      within("#budget-investments") do
-        expect(page).to have_css(".budget-investment", count: 1)
-
-        expect(page).to have_content "Seaport"
-        expect(page).not_to have_content "Terminal 5"
-        expect(page).not_to have_content "Airport"
       end
     end
 

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -269,7 +269,11 @@ describe "Tags" do
 
         login_as(admin) if budget.drafting?
         visit budget_path(budget)
-        click_link group.name
+        if budget.informing?
+          visit budget_investments_path(budget, heading: heading.id)
+        else
+          click_link "See all investments"
+        end
 
         within "#tag-cloud" do
           click_link new_tag
@@ -318,7 +322,11 @@ describe "Tags" do
 
         login_as(admin) if budget.drafting?
         visit budget_path(budget)
-        click_link group.name
+        if budget.informing?
+          visit budget_investments_path(budget, heading: heading.id)
+        else
+          click_link "See all investments"
+        end
 
         within "#categories" do
           click_link tag_medio_ambiente.name


### PR DESCRIPTION
## Objectives

There was a big difference between the current budget and a specific budget landing page. This didn't really make too much sense. Also, it was not possible to know how a draft participatory budget will look before it was published.
By unifying those two views now they will look quite similar and it will be possible for administrators to preview any draft budget and to know how the budget will look like before actually publishing it.
