### PR TITLE
Add filters on budget investments index page

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1124,6 +1124,10 @@ form {
     &:not(.locale-switcher) {
       min-height: $line-height * 2;
     }
+
+    &:focus {
+      border: 2px solid #d2d7dc;
+    }
   }
 
   [type="radio"] {

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1214,6 +1214,17 @@
   }
 }
 
+.filter-selector {
+
+  label {
+    padding-top: $line-height / 2;
+  }
+
+  select {
+    width: auto;
+  }
+}
+
 // 05. Featured
 // ------------
 

--- a/app/views/budgets/investments/index.html.erb
+++ b/app/views/budgets/investments/index.html.erb
@@ -70,6 +70,10 @@
         <%= render("shared/order_links", i18n_namespace: "budgets.investments.index") %>
       <% end %>
 
+      <div class="float-right">
+        <%= render "shared/filter_selector", i18n_namespace: "budgets.investments.index" %>
+      </div>
+
       <% if investments_default_view? %>
 
         <% @investments.each do |investment| %>

--- a/app/views/shared/_filter_selector.html.erb
+++ b/app/views/shared/_filter_selector.html.erb
@@ -1,0 +1,19 @@
+<form class="inline-block medium-collapse filter-selector">
+  <div class="small-12 medium-6 column">
+    <label for="filter_selector" class="small"><%= t("#{i18n_namespace}.filter") %></label>
+  </div>
+  <div class="small-12 medium-6 column">
+    <select class="js-location-changer"
+            data-order="<%= @current_filter %>"
+            name="filter-selector"
+            id="filter_selector"
+            title="<%= t("#{i18n_namespace}.filter") %>">
+      <% @valid_filters.each do |filter| %>
+        <option <%= "selected" if filter == @current_filter %>
+          value="<%= current_path_with_query_params(filter: filter, page: 1) %>">
+          <%= t("#{i18n_namespace}.filters.#{filter}") %>
+        </option>
+      <% end %>
+    </select>
+  </div>
+</form>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -125,6 +125,7 @@ ignore_missing:
 ## Consider these keys used:
 ignore_unused:
   - "budgets.phase.*"
+  - "budgets.investments.index.filter*"
   - "budgets.investments.index.orders.*"
   - "budgets.index.section_header.*"
   - "activerecord.*"

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -102,6 +102,15 @@ en:
           by_feasibility: By feasibility
           feasible: Feasible projects
           unfeasible: Unfeasible projects
+        filter: "Filtering projects by"
+        filters:
+          all: "All"
+          not_unfeasible: "Not unfeasible"
+          feasible: "Feasible"
+          unfeasible: "Unfeasible"
+          unselected: "Unselected"
+          selected: "Selected"
+          winners: "Winners"
         orders:
           random: random
           confidence_score: highest rated

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -102,6 +102,14 @@ es:
           by_feasibility: Por viabilidad
           feasible: Ver los proyectos viables
           unfeasible: Ver los proyectos inviables
+        filter: "Filtrando proyectos"
+        filters:
+          not_unfeasible: "No inviables"
+          feasible: "Viables"
+          unfeasible: "No viables"
+          unselected: "No seleccionados"
+          selected: "Seleccionados"
+          winners: "Ganadores"
         orders:
           random: Aleatorios
           confidence_score: Mejor valorados

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -152,6 +152,59 @@ describe "Budget Investments" do
     end
   end
 
+  scenario "Index filter by status", :js do
+    budget_new  = create(:budget)
+    group_new   = create(:budget_group, budget: budget_new)
+    heading_new = create(:budget_heading, group: group_new)
+
+    create_list(:budget_investment, 2, :feasible, heading: heading_new)
+    create_list(:budget_investment, 2, :unfeasible, heading: heading_new)
+    create_list(:budget_investment, 2, :unselected, heading: heading_new)
+    create_list(:budget_investment, 2, :selected, heading: heading_new)
+    create_list(:budget_investment, 2, :winner, heading: heading_new)
+
+    visit budget_investments_path(budget_new, heading_id: heading_new.id)
+
+    expect(page).to have_select("filter_selector", options: ["Not unfeasible", "Feasible", "Unfeasible",
+                                                             "Unselected", "Selected", "Winners"])
+
+    select "Feasible", from: "filter_selector"
+    feasible_path = budget_investments_path(budget_new, heading_id: heading_new.id,
+                                                        filter: "feasible", page: "1")
+    expect(page).to have_current_path(feasible_path)
+    expect(page).to have_css(".budget-investment", count: 8)
+
+    select "Unfeasible", from: "filter_selector"
+    unfeasible_path = budget_investments_path(budget_new, heading_id: heading_new.id,
+                                                          filter: "unfeasible", page: "1")
+    expect(page).to have_current_path(unfeasible_path)
+    expect(page).to have_css(".budget-investment", count: 2)
+
+    select "Unselected", from: "filter_selector"
+    unselected_path = budget_investments_path(budget_new, heading_id: heading_new.id,
+                                                          filter: "unselected", page: "1")
+    expect(page).to have_current_path(unselected_path)
+    expect(page).to have_css(".budget-investment", count: 4)
+
+    select "Selected", from: "filter_selector"
+    selected_path = budget_investments_path(budget_new, heading_id: heading_new.id,
+                                                        filter: "selected", page: "1")
+    expect(page).to have_current_path(selected_path)
+    expect(page).to have_css(".budget-investment", count: 4)
+
+    select "Winners", from: "filter_selector"
+    winners_path = budget_investments_path(budget_new, heading_id: heading_new.id,
+                                                       filter: "winners", page: "1")
+    expect(page).to have_current_path(winners_path)
+    expect(page).to have_css(".budget-investment", count: 2)
+
+    select "Not unfeasible", from: "filter_selector"
+    not_unfeasible_path = budget_investments_path(budget_new, heading_id: heading_new.id,
+                                                              filter: "not_unfeasible", page: "1")
+    expect(page).to have_current_path(not_unfeasible_path)
+    expect(page).to have_css(".budget-investment", count: 8)
+  end
+
   context("Search") do
     scenario "Search by text" do
       investment1 = create(:budget_investment, heading: heading, title: "Get Schwifty")


### PR DESCRIPTION
## Objectives

Add filters on budget investments index page to filter investments depending on their status:

- Not unfeasible
- Feasible
- Unfeasible
- Unselected
- Selected
- Winners

## Visual Changes

![filters](https://user-images.githubusercontent.com/631897/81180261-0e47fd80-8fab-11ea-8665-424ba84518e0.png)

![filters_2](https://user-images.githubusercontent.com/631897/81180268-11db8480-8fab-11ea-8726-7b9d22bb9903.png)

