### PR TITLE
Check terms of service by default on new forms

### DIFF
--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -107,12 +107,7 @@
       <% unless current_user.manager? %>
         <p class="form-label"><%= t("shared.required_fields") %></p>
 
-        <%= f.check_box :terms_of_service,
-          title: t("form.accept_terms_title"),
-          label: t("form.accept_terms",
-                   policy: link_to(t("form.policy"), "/privacy", target: "blank"),
-                   conditions: link_to(t("form.conditions"), "/conditions", target: "blank")
-                  ) %>
+        <%= f.hidden_field :terms_of_service, value: 1 %>
       <% end %>
 
       <%= f.submit(nil, class: "button large margin-top") %>

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -50,12 +50,7 @@
       <% if @debate.new_record? %>
         <p class="form-label"><%= t("shared.required_fields") %></p>
 
-        <%= f.check_box :terms_of_service,
-          title: t("form.accept_terms_title"),
-          label: t("form.accept_terms",
-                   policy: link_to(t("form.policy"), "/privacy", target: "blank"),
-                   conditions: link_to(t("form.conditions"), "/conditions", target: "blank")
-                  ) %>
+        <%= f.hidden_field :terms_of_service, value: 1 %>
       <% end %>
 
       <%= f.submit(class: "button large margin-top", value: t("debates.#{action_name}.form.submit_button")) %>

--- a/app/views/legislation/proposals/_form.html.erb
+++ b/app/views/legislation/proposals/_form.html.erb
@@ -60,12 +60,7 @@
 
     <div class="small-12 column">
       <% if @proposal.new_record? %>
-        <%= f.check_box :terms_of_service,
-          title: t("form.accept_terms_title"),
-          label: t("form.accept_terms",
-                   policy: link_to(t("form.policy"), "/privacy", target: "blank"),
-                   conditions: link_to(t("form.conditions"), "/conditions", target: "blank")
-                  ) %>
+        <%= f.hidden_field :terms_of_service, value: 1 %>
       <% end %>
     </div>
 

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -110,12 +110,7 @@
       <% if @proposal.new_record? %>
         <p class="form-label"><%= t("shared.required_fields") %></p>
 
-        <%= f.check_box :terms_of_service,
-          title: t("form.accept_terms_title"),
-          label: t("form.accept_terms",
-                   policy: link_to(t("form.policy"), "/privacy", target: "blank"),
-                   conditions: link_to(t("form.conditions"), "/conditions", target: "blank")
-                  ) %>
+        <%= f.hidden_field :terms_of_service, value: 1 %>
       <% end %>
 
       <%= f.submit(class: "button large margin-top",

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -842,7 +842,8 @@ describe "Budget Investments" do
       fill_in "Title", with: "I am a bot"
       fill_in "budget_investment_subtitle", with: "This is the honeypot"
       fill_in "Description", with: "This is the description"
-      check   "I agree to the Privacy Policy and the Terms and conditions of use"
+      # Check terms of service by default
+      # check "I agree to the Privacy Policy and the Terms and conditions of use"
 
       click_button "Create Investment"
 
@@ -862,7 +863,8 @@ describe "Budget Investments" do
 
       fill_in "Title", with: "I am a bot"
       fill_in "Description", with: "This is the description"
-      check   "I agree to the Privacy Policy and the Terms and conditions of use"
+      # Check terms of service by default
+      # check "I agree to the Privacy Policy and the Terms and conditions of use"
 
       click_button "Create Investment"
 
@@ -886,7 +888,8 @@ describe "Budget Investments" do
       fill_in "If you are proposing in the name of a collective/organization, "\
               "or on behalf of more people, write its name", with: "T.I.A."
       fill_in "Tags", with: "Towers"
-      check   "I agree to the Privacy Policy and the Terms and conditions of use"
+      # Check terms of service by default
+      # check "I agree to the Privacy Policy and the Terms and conditions of use"
 
       click_button "Create Investment"
 
@@ -923,7 +926,8 @@ describe "Budget Investments" do
       fill_in "budget_investment_location", with: "City center"
       fill_in "budget_investment_organization_name", with: "T.I.A."
       fill_in "budget_investment_tag_list", with: "Towers"
-      check   "budget_investment_terms_of_service"
+      # Check terms of service by default
+      # check "budget_investment_terms_of_service"
 
       click_button "Create Investment"
 
@@ -950,7 +954,8 @@ describe "Budget Investments" do
 
       click_link("Edit", match: :first)
       fill_in "Title", with: "Park improvements"
-      check "budget_investment_terms_of_service"
+      # Check terms of service by default
+      # check "budget_investment_terms_of_service"
 
       click_button "Update Investment"
 
@@ -968,7 +973,8 @@ describe "Budget Investments" do
       visit user_path(daniel, filter: "budget_investments")
       click_link("Edit", match: :first)
       fill_in "Title", with: ""
-      check "budget_investment_terms_of_service"
+      # Check terms of service by default
+      # check "budget_investment_terms_of_service"
 
       click_button "Update Investment"
 

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -178,7 +178,8 @@ describe "Debates" do
     visit new_debate_path
     fill_in "Debate title", with: "A title for a debate"
     fill_in "Initial debate text", with: "This is very important because..."
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     click_button "Start a debate"
 
@@ -197,7 +198,8 @@ describe "Debates" do
     fill_in "Debate title", with: "I am a bot"
     fill_in "debate_subtitle", with: "This is a honeypot field"
     fill_in "Initial debate text", with: "This is the description"
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     click_button "Start a debate"
 
@@ -215,7 +217,8 @@ describe "Debates" do
     visit new_debate_path
     fill_in "Debate title", with: "I am a bot"
     fill_in "Initial debate text", with: "This is the description"
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     click_button "Start a debate"
 
@@ -240,7 +243,8 @@ describe "Debates" do
     visit new_debate_path
     fill_in "Debate title", with: "Testing an attack"
     fill_in "Initial debate text", with: "<p>This is <script>alert('an attack');</script></p>"
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     click_button "Start a debate"
 
@@ -258,7 +262,8 @@ describe "Debates" do
     visit new_debate_path
     fill_in "Debate title", with: "Testing auto link"
     fill_in "Initial debate text", with: "<p>This is a link www.example.org</p>"
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     click_button "Start a debate"
 
@@ -275,7 +280,8 @@ describe "Debates" do
     visit new_debate_path
     fill_in "Debate title", with: "Testing auto link"
     fill_in "Initial debate text", with: js_injection_string
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     click_button "Start a debate"
 
@@ -1078,7 +1084,8 @@ describe "Debates" do
       login_as(create(:user))
       visit new_debate_path
       fill_in "Debate title", with: "debate"
-      check "debate_terms_of_service"
+      # Check terms of service by default
+      # check "debate_terms_of_service"
 
       within("div.js-suggest") do
         expect(page).to have_content "You are seeing 5 of 6 debates containing the term 'debate'"
@@ -1092,7 +1099,8 @@ describe "Debates" do
       login_as(create(:user))
       visit new_debate_path
       fill_in "Debate title", with: "proposal"
-      check "debate_terms_of_service"
+      # Check terms of service by default
+      # check "debate_terms_of_service"
 
       within("div.js-suggest") do
         expect(page).not_to have_content "You are seeing"

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -349,7 +349,8 @@ describe "Emails" do
 
       fill_in "Title", with: "Build a hospital"
       fill_in "Description", with: "We have lots of people that require medical attention"
-      check   "budget_investment_terms_of_service"
+      # Check terms of service by default
+      # check "budget_investment_terms_of_service"
 
       click_button "Create Investment"
       expect(page).to have_content "Investment created successfully"

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -146,7 +146,8 @@ describe "Legislation Proposals" do
     fill_in "Proposal title", with: "Legislation proposal with image"
     fill_in "Proposal summary", with: "Including an image on a legislation proposal"
     imageable_attach_new_file(create(:image), Rails.root.join("spec/fixtures/files/clippy.jpg"))
-    check "legislation_proposal_terms_of_service"
+    # Check terms of service by default
+    # check "legislation_proposal_terms_of_service"
     click_button "Create proposal"
 
     expect(page).to have_content "Legislation proposal with image"

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -23,7 +23,8 @@ describe "Proposals" do
       fill_in "Proposal summary", with: "In summary, what we want is..."
       fill_in "Proposal text", with: "This is very important because..."
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yRYFKcMa_Ek"
-      check "proposal_terms_of_service"
+      # Check terms of service by default
+      # check "proposal_terms_of_service"
 
       click_button "Create proposal"
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -266,7 +266,8 @@ describe "Proposals" do
     fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_tag_list", with: "Refugees, Solidarity"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     click_button "Create proposal"
 
@@ -299,7 +300,8 @@ describe "Proposals" do
     fill_in "Proposal summary", with: "This is the summary"
     fill_in "Proposal text", with: "This is the description"
     fill_in "proposal_responsible_name", with: "Some other robot"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     click_button "Create proposal"
 
@@ -319,7 +321,8 @@ describe "Proposals" do
     fill_in "Proposal summary", with: "This is the summary"
     fill_in "Proposal text", with: "This is the description"
     fill_in "proposal_responsible_name", with: "Some other robot"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     click_button "Create proposal"
 
@@ -338,7 +341,8 @@ describe "Proposals" do
     fill_in "Proposal text", with: "This is very important because..."
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     click_button "Create proposal"
 
@@ -359,7 +363,8 @@ describe "Proposals" do
     fill_in "Proposal title", with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in "Proposal text", with: "This is very important because..."
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     click_button "Create proposal"
     expect(page).to have_content "Proposal created successfully."
@@ -388,7 +393,8 @@ describe "Proposals" do
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in "Proposal text", with: "<p>This is <script>alert('an attack');</script></p>"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     click_button "Create proposal"
 
@@ -411,7 +417,8 @@ describe "Proposals" do
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in "Proposal text", with: "<p>This is a link www.example.org</p>"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     click_button "Create proposal"
 
@@ -433,7 +440,8 @@ describe "Proposals" do
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in "Proposal text", with: js_injection_string
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     click_button "Create proposal"
 
@@ -490,7 +498,8 @@ describe "Proposals" do
       fill_in "Proposal text", with: "This is very important because..."
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
       fill_in "proposal_responsible_name", with: "Isabel Garcia"
-      check "proposal_terms_of_service"
+      # Check terms of service by default
+      # check "proposal_terms_of_service"
 
       select("California", from: "proposal_geozone_id")
       click_button "Create proposal"
@@ -1708,7 +1717,8 @@ describe "Proposals" do
       login_as(create(:user))
       visit new_proposal_path
       fill_in "Proposal title", with: "search"
-      check "proposal_terms_of_service"
+      # Check terms of service by default
+      # check "proposal_terms_of_service"
 
       within("div.js-suggest") do
         expect(page).to have_content "You are seeing 5 of 6 proposals containing the term 'search'"
@@ -1722,7 +1732,8 @@ describe "Proposals" do
       login_as(create(:user))
       visit new_proposal_path
       fill_in "Proposal title", with: "debate"
-      check "proposal_terms_of_service"
+      # Check terms of service by default
+      # check "proposal_terms_of_service"
 
       within("div.js-suggest") do
         expect(page).not_to have_content "You are seeing"
@@ -1895,7 +1906,8 @@ describe "Successful proposals" do
       fill_in "Proposal text", with: "This is very important because..."
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
       fill_in "proposal_tag_list", with: "Refugees, Solidarity"
-      check "proposal_terms_of_service"
+      # Check terms of service by default
+      # check "proposal_terms_of_service"
 
       click_button "Create proposal"
 

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -71,7 +71,8 @@ describe "Tags" do
 
     fill_in "Title", with: "Build a skyscraper"
     fill_in "Description", with: "I want to live in a high tower over the clouds"
-    check   "budget_investment_terms_of_service"
+    # Check terms of service by default
+    # check "budget_investment_terms_of_service"
 
     fill_in "budget_investment_tag_list", with: "#{tag_medio_ambiente.name}, #{tag_economia.name}"
 
@@ -92,7 +93,8 @@ describe "Tags" do
 
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
-    check "budget_investment_terms_of_service"
+    # Check terms of service by default
+    # check "budget_investment_terms_of_service"
 
     find(".js-add-tag-link", text: tag_economia.name).click
     click_button "Create Investment"
@@ -118,7 +120,8 @@ describe "Tags" do
 
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
-    check "budget_investment_terms_of_service"
+    # Check terms of service by default
+    # check "budget_investment_terms_of_service"
 
     find(".js-add-tag-link", text: "Education").click
     click_button "Create Investment"
@@ -144,7 +147,8 @@ describe "Tags" do
 
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
-    check "budget_investment_terms_of_service"
+    # Check terms of service by default
+    # check "budget_investment_terms_of_service"
 
     find(".js-add-tag-link", text: "Education").click
     click_button "Create Investment"
@@ -167,7 +171,8 @@ describe "Tags" do
 
     fill_in "Title", with: "Build a skyscraper"
     fill_in "Description", with: "I want to live in a high tower over the clouds"
-    check   "budget_investment_terms_of_service"
+    # Check terms of service by default
+    # check   "budget_investment_terms_of_service"
 
     fill_in "budget_investment_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
 
@@ -187,7 +192,8 @@ describe "Tags" do
 
     fill_in "Title", with: "Build a skyscraper"
     fill_in "Description", with: "I want to live in a high tower over the clouds"
-    check   "budget_investment_terms_of_service"
+    # Check terms of service by default
+    # check   "budget_investment_terms_of_service"
 
     fill_in "budget_investment_tag_list", with: "user_id=1, &a=3, <script>alert('hey');</script>"
 

--- a/spec/features/tags/debates_spec.rb
+++ b/spec/features/tags/debates_spec.rb
@@ -67,7 +67,8 @@ describe "Tags" do
     visit new_debate_path
     fill_in "Debate title", with: "Title"
     fill_in "Initial debate text", with: "Description"
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda"
 
@@ -86,7 +87,8 @@ describe "Tags" do
     visit new_debate_path
     fill_in "Debate title", with: "Title"
     fill_in "Initial debate text", with: "Description"
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
 
@@ -104,7 +106,8 @@ describe "Tags" do
 
     fill_in "Debate title", with: "A test of dangerous strings"
     fill_in "Initial debate text", with: "A description suitable for this test"
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "user_id=1, &a=3, <script>alert('hey');</script>"
 

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -69,7 +69,8 @@ describe "Tags" do
     fill_in "Proposal text", with: "This is very important because..."
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_tag_list", with: "Economía, Hacienda"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     click_button "Create proposal"
 
@@ -93,7 +94,8 @@ describe "Tags" do
     fill_in_ckeditor "Proposal text", with: "A description with enough characters"
     fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=Ae6gQmhaMn4"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     find(".js-add-tag-link", text: "Education").click
     click_button "Create proposal"
@@ -115,7 +117,8 @@ describe "Tags" do
     visit new_proposal_path
     fill_in "Proposal title", with: "Title"
     fill_in "Proposal text", with: "Description"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     fill_in "proposal_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
 
@@ -135,7 +138,8 @@ describe "Tags" do
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in "Proposal text", with: "A description suitable for this test"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
 
     fill_in "proposal_tag_list", with: "user_id=1, &a=3, <script>alert('hey');</script>"
 

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -60,7 +60,8 @@ describe "Tags" do
     visit new_debate_path
     fill_in "Debate title", with: "Title"
     fill_in "Initial debate text", with: "Description"
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda"
 
@@ -79,7 +80,8 @@ describe "Tags" do
     visit new_debate_path
     fill_in "Debate title", with: "Title"
     fill_in "Initial debate text", with: "Description"
-    check "debate_terms_of_service"
+    # Check terms of service by default
+    # check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
 

--- a/spec/features/translatable_spec.rb
+++ b/spec/features/translatable_spec.rb
@@ -14,7 +14,8 @@ describe "Public area translatable records" do
 
       fill_in "Debate title", with: "Who won the debate?"
       fill_in_ckeditor "Initial debate text", with: "And who will win this debate?"
-      check "debate_terms_of_service"
+      # Check terms of service by default
+      # check "debate_terms_of_service"
       click_button "Start a debate"
 
       expect(page).to have_content "Debate created successfully"
@@ -26,7 +27,8 @@ describe "Public area translatable records" do
       fill_in "Proposal title", with: "Olympic Games in Melbourne"
       fill_in "Proposal summary", with: "Full proposal for our candidature"
       fill_in_ckeditor "Proposal text", with: "2032 will make Australia famous again"
-      check "proposal_terms_of_service"
+      # Check terms of service by default
+      # check "proposal_terms_of_service"
       click_button "Create proposal"
 
       expect(page).to have_content "Proposal created successfully"
@@ -50,7 +52,8 @@ describe "Public area translatable records" do
       expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{budget.id}\"]",
                                      visible: false)
 
-      check "budget_investment_terms_of_service"
+      # Check terms of service by default
+      # check "budget_investment_terms_of_service"
       click_button "Create Investment"
 
       expect(page).to have_content "Budget Investment created successfully"
@@ -63,7 +66,8 @@ describe "Public area translatable records" do
 
       fill_in "Proposal title", with: "Titre en Français"
       fill_in "Proposal summary", with: "Résumé en Français"
-      check "proposal_terms_of_service"
+      # Check terms of service by default
+      # check "proposal_terms_of_service"
       click_button "Create proposal"
 
       expect(page).to have_content "Proposal created successfully"
@@ -81,7 +85,8 @@ describe "Public area translatable records" do
       expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{budget.id}\"]",
                                      visible: false)
 
-      check "budget_investment_terms_of_service"
+      # Check terms of service by default
+      # check "budget_investment_terms_of_service"
       click_button "Create Investment"
 
       expect(page).to have_content "Budget Investment created successfully"
@@ -90,7 +95,8 @@ describe "Public area translatable records" do
     scenario "Add an invalid translation" do
       visit new_debate_path
 
-      check "debate_terms_of_service"
+      # Check terms of service by default
+      # check "debate_terms_of_service"
       click_button "Start a debate"
 
       expect(page).to have_css "#error_explanation"
@@ -106,7 +112,8 @@ describe "Public area translatable records" do
       expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{budget.id}\"]",
                                      visible: false)
 
-      check "budget_investment_terms_of_service"
+      # Check terms of service by default
+      # check "budget_investment_terms_of_service"
       click_button "Create Investment"
 
       expect(page).to have_css "#error_explanation"

--- a/spec/shared/features/mappable.rb
+++ b/spec/shared/features/mappable.rb
@@ -213,7 +213,8 @@ def fill_in_proposal_form
 end
 
 def submit_proposal_form
-  check :proposal_terms_of_service
+  # Check terms of service by default
+  # check :proposal_terms_of_service
   click_button "Create proposal"
 
   if page.has_content?("Not now, go to my proposal")
@@ -231,11 +232,13 @@ end
 def fill_in_budget_investment_form
   fill_in "Title", with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
-  check :budget_investment_terms_of_service
+  # Check terms of service by default
+  # check :budget_investment_terms_of_service
 end
 
 def submit_budget_investment_form
-  check :budget_investment_terms_of_service
+  # Check terms of service by default
+  # check :budget_investment_terms_of_service
   click_button "Create Investment"
 end
 

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -346,7 +346,8 @@ end
 def documentable_fill_new_valid_proposal
   fill_in "Proposal title", with: "Proposal title #{rand(9999)}"
   fill_in "Proposal summary", with: "Proposal summary"
-  check :proposal_terms_of_service
+  # Check terms of service by default
+  # check :proposal_terms_of_service
 end
 
 def documentable_fill_new_valid_dashboard_action
@@ -357,5 +358,6 @@ end
 def documentable_fill_new_valid_budget_investment
   fill_in "Title", with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
-  check :budget_investment_terms_of_service
+  # Check terms of service by default
+  # check :budget_investment_terms_of_service
 end

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -278,7 +278,8 @@ end
 def imageable_fill_new_valid_proposal
   fill_in "Proposal title", with: "Proposal title"
   fill_in "Proposal summary", with: "Proposal summary"
-  check :proposal_terms_of_service
+  # Check terms of service by default
+  # check :proposal_terms_of_service
 end
 
 def imageable_fill_new_valid_budget
@@ -288,7 +289,8 @@ end
 def imageable_fill_new_valid_budget_investment
   fill_in "Title", with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
-  check :budget_investment_terms_of_service
+  # Check terms of service by default
+  # check :budget_investment_terms_of_service
 end
 
 def expect_image_has_title(title)

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -33,7 +33,8 @@ module CommonActions
     fill_in "Proposal text", with: "This is very important because..."
     fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
-    check "proposal_terms_of_service"
+    # Check terms of service by default
+    # check "proposal_terms_of_service"
   end
 
   def set_officing_booth(booth = nil)


### PR DESCRIPTION
## Objectives

This PR replaces the terms and conditions checkbox with`<%= f.hidden_field :terms_of_service, value: 1 %>` to avoid users having to re-accept terms and conditions when creating debates, proposals, budget investments, legislation debates, and legislation proposals.
