### PR TITLE
Count debate votes correctly

### DIFF
--- a/app/views/debates/_votes.html.erb
+++ b/app/views/debates/_votes.html.erb
@@ -40,7 +40,7 @@
   </div>
 
   <span class="total-votes">
-    <%= t("debates.debate.votes", count: debate.votes_score) %>
+    <%= t("debates.debate.votes", count: debate.total_votes) %>
   </span>
 
   <% if user_signed_in? && current_user.organization? %>

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -134,41 +134,48 @@ describe "Debates" do
     end
   end
 
-  scenario "Show votes score on index and show" do
-    debate_positive = create(:debate, title: "Debate positive")
-    debate_zero = create(:debate, title: "Debate zero")
-    debate_negative = create(:debate, title: "Debate negative")
+  scenario "Show total votes on index and show" do
+    debate_with_postive_votes = create(:debate, title: "Liked Debate")
+    2.times { create(:vote, votable: debate_with_postive_votes, vote_flag: true) }
 
-    10.times { create(:vote, votable: debate_positive, vote_flag: true) }
-    3.times  { create(:vote, votable: debate_positive, vote_flag: false) }
+    debate_with_negative_votes = create(:debate, title: "Unliked Debate")
+    3.times { create(:vote, votable: debate_with_negative_votes, vote_flag: false) }
 
-    5.times { create(:vote, votable: debate_zero, vote_flag: true) }
-    5.times  { create(:vote, votable: debate_zero, vote_flag: false) }
+    debate_with_both_votes = create(:debate, title: "Voted Debate")
+    3.times { create(:vote, votable: debate_with_both_votes, vote_flag: true) }
+    2.times { create(:vote, votable: debate_with_both_votes, vote_flag: false) }
 
-    6.times  { create(:vote, votable: debate_negative, vote_flag: false) }
+    debate_without_votes = create(:debate, title: "Unvoted Debate")
 
     visit debates_path
 
-    within "#debate_#{debate_positive.id}" do
-      expect(page).to have_content("7 votes")
+    within "#debate_#{debate_with_postive_votes.id}" do
+      expect(page).to have_content("2 votes")
     end
 
-    within "#debate_#{debate_zero.id}" do
+    within "#debate_#{debate_with_negative_votes.id}" do
+      expect(page).to have_content("3 votes")
+    end
+
+    within "#debate_#{debate_with_both_votes.id}" do
+      expect(page).to have_content("5 votes")
+    end
+
+    within "#debate_#{debate_without_votes.id}" do
       expect(page).to have_content("No votes")
     end
 
-    within "#debate_#{debate_negative.id}" do
-      expect(page).to have_content("-6 votes")
-    end
+    visit debate_path(debate_with_postive_votes)
+    expect(page).to have_content("2 votes")
 
-    visit debate_path(debate_positive)
-    expect(page).to have_content("7 votes")
+    visit debate_path(debate_with_negative_votes)
+    expect(page).to have_content("3 votes")
 
-    visit debate_path(debate_zero)
+    visit debate_path(debate_with_both_votes)
+    expect(page).to have_content("5 votes")
+
+    visit debate_path(debate_without_votes)
     expect(page).to have_content("No votes")
-
-    visit debate_path(debate_negative)
-    expect(page).to have_content("-6 votes")
   end
 
   scenario "Create" do

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -126,7 +126,7 @@ describe "Votes" do
 
         visit debate_path(debate)
 
-        expect(page).to have_content "No votes"
+        expect(page).to have_content "2 votes"
 
         within(".in-favor") do
           expect(page).to have_content "50%"


### PR DESCRIPTION
## Objectives

Count debate votes correctly

Previously the score was shown, but not the real total votes. 
For example, if a debate had 2 votes, one positive and one negative, "0 votes" was shown, but the total votes is "2 votes"

## Visual Changes

- Example with 2 positive votes and 1 negative vote.

### BEFORE
![Captura de pantalla 2020-06-25 a las 12 58 30](https://user-images.githubusercontent.com/942995/85663811-b9d81900-b6e3-11ea-97d6-0324f6058b5a.png)

### AFTER
![Captura de pantalla 2020-06-25 a las 12 58 45](https://user-images.githubusercontent.com/942995/85663826-be9ccd00-b6e3-11ea-8d2f-6a4cff2ace23.png)
