### PR TITLE
Stop using Knapsack Pro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,16 @@ before_script:
 - bundle exec rake db:setup
 script:
 - "bundle exec rake assets:precompile RAILS_ENV=test > /dev/null 2>&1"
-- "bin/knapsack_pro_rspec"
+- "bundle exec rake knapsack:rspec"
 env:
   global:
-  - KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
-  - KNAPSACK_PRO_LOG_LEVEL=info
-  - KNAPSACK_PRO_CI_NODE_TOTAL=5
+  - CI_NODE_TOTAL=5
   matrix:
-  - KNAPSACK_PRO_CI_NODE_INDEX=0
-  - KNAPSACK_PRO_CI_NODE_INDEX=1
-  - KNAPSACK_PRO_CI_NODE_INDEX=2
-  - KNAPSACK_PRO_CI_NODE_INDEX=3
-  - KNAPSACK_PRO_CI_NODE_INDEX=4
+  - CI_NODE_INDEX=0
+  - CI_NODE_INDEX=1
+  - CI_NODE_INDEX=2
+  - CI_NODE_INDEX=3
+  - CI_NODE_INDEX=4
 notifications:
   slack:
     secure: 18E9SU0SR/9knRvCMYwVqFCqVTBT6qJtZQ/gadpheqUPPlcLoQfnlIzJkLIYqkE0sn1nkBE5Bt2I90FU53p0NkrTEmSGlQXcN1vEXM8EXMaoVf3NBsIJeleMwt9VTojzo81EgIi6x7q3fDiFORJ4rqOGd9XkeLn5yrAtIkdaenVs0bhS5s24FP76hKqO37IFLG2v3EEqxg5k31oW6yhyP35Mxns+AGbfaZbxEy4XbCoU65KFuYhBsVZ/y1evOl/wcre2fCAoT2uKeqUWGEcDzH7oSCz7vfk7iO9BZnO++v7oj8mr/nrZL1KMFt77eqtdT51XQoJcchgJC/R9km5hRGkQqFCHhqPcBxo5c3p+jauL0kLaqTggeLDv2FQ2huJ8FSJ4ADac+n3g7wT7BX7HJlCvK0nbooY1JtBlk7+6/pw6ksSFIOo0FHg5gXN9IlG1tQQuENzzsXULNc6s4nPeT+n78uOp1b0N/Gn06moEBaKgXqqx1yV1XeJ02X8n3uDZxPuX3n2bJ4DMIrBjeWApxHAgyOraOzQHNQgJoj4tHlWutF33ApV2tcIMefIzvjM4tIYwIkpfGgohGaTf8eU5X9pqiMgwlDpJHVBsSvpk/Z/Nj7evYznjBiDYqOcXoztsqHrS0C91MaT+eExDfd9HDmThsE07RT7zcP9aElFZA/k=

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ group :development, :test do
   gem "factory_bot_rails", "~> 4.8.2"
   gem "faker", "~> 1.8.7"
   gem "i18n-tasks", "~> 0.9.29"
-  gem "knapsack_pro", "~> 1.15.0"
+  gem "knapsack", "~> 1.18"
   gem "launchy", "~> 2.4.3"
   gem "letter_opener_web", "~> 1.3.4"
   gem "spring", "~> 2.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
-    knapsack_pro (1.15.0)
+    knapsack (1.18.0)
       rake
     kramdown (1.17.0)
     launchy (2.4.3)
@@ -653,7 +653,7 @@ DEPENDENCIES
   jquery-rails (~> 4.3.3)
   jquery-ui-rails (~> 6.0.1)
   kaminari (~> 1.1.1)
-  knapsack_pro (~> 1.15.0)
+  knapsack (~> 1.18)
   launchy (~> 2.4.3)
   letter_opener_web (~> 1.3.4)
   mdl (~> 0.5.0)

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@
 require File.expand_path("../config/application", __FILE__)
 
 Rails.application.load_tasks if Rake::Task.tasks.empty?
-KnapsackPro.load_tasks if defined?(KnapsackPro)
+Knapsack.load_tasks if defined?(Knapsack)
 
 if Rails.env.development?
   require "github_changelog_generator/task"

--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -1,9 +1,0 @@
-#!/bin/bash
-if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
-  KNAPSACK_PRO_ENDPOINT=https://api-disabled-for-fork.knapsackpro.com \
-    KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
-    bundle exec rake knapsack_pro:rspec # use Regular Mode here always
-else
-  # Queue Mode - dynamic tests allocation across CI nodes
-  bundle exec rake knapsack_pro:queue:rspec
-fi

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require "factory_bot_rails"
 require "database_cleaner"
 require "email_spec"
 require "devise"
-require "knapsack_pro"
+require "knapsack"
 
 Dir["./spec/models/concerns/*.rb"].each { |f| require f }
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
@@ -163,4 +163,4 @@ RSpec.configure do |config|
 end
 
 # Parallel build helper configuration for travis
-KnapsackPro::Adapters::RSpecAdapter.bind
+Knapsack::Adapters::RSpecAdapter.bind


### PR DESCRIPTION
## Objectives

Use `Knapsack` instead of `KnapsackPro` to splits tests across CI nodes.