### PR TITLE
Add alert to confirm proposal support

### DIFF
--- a/app/views/proposals/_votes.html.erb
+++ b/app/views/proposals/_votes.html.erb
@@ -9,7 +9,8 @@
     <% elsif user_signed_in? && proposal.votable_by?(current_user) %>
       <%= link_to vote_url,
           class: "button button-support small expanded",
-          title: t("proposals.proposal.support_title"), method: "post", remote: true do %>
+          title: t("proposals.proposal.support_title"), method: "post", remote: true,
+          data: { confirm: t("proposals.shared.confirm_support", proposal: proposal.title) } do %>
         <%= t("proposals.proposal.support") %>
       <% end %>
     <% else %>

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -54,6 +54,8 @@ en:
         recommendations: "Recommendations"
     form:
       tags_label: "Onderwerpen/labels"
+    shared:
+      confirm_support: "Are you sure? You will support the proposal \"%{proposal}\" and this action cannot be undone."
   polls:
     index:
       section_header:

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -138,7 +138,7 @@ describe "Proposals" do
       click_link "Support proposals"
 
       within(".proposals-list") do
-        click_link("Support")
+        accept_confirm { click_link "Support" }
         expect(page).to have_content "1 support"
         expect(page).to have_content "You have already supported this proposal. Share it!"
       end
@@ -154,7 +154,10 @@ describe "Proposals" do
 
       within(".proposals-list") { click_link proposal.title }
       expect(page).to have_content proposal.code
-      within("#proposal_#{proposal.id}_votes") { click_link("Support") }
+
+      within("#proposal_#{proposal.id}_votes") do
+        accept_confirm { click_link "Support" }
+      end
 
       expect(page).to have_content "1 support"
       expect(page).to have_content "You have already supported this proposal. Share it!"

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -218,7 +218,7 @@ describe "Votes" do
         visit proposal_path(proposal)
 
         within(".supports") do
-          find(".in-favor a").click
+          accept_confirm { find(".in-favor a").click }
           expect(page).to have_content "1 support"
 
           expect(page).not_to have_selector ".in-favor a"
@@ -240,7 +240,7 @@ describe "Votes" do
         visit proposal_path(proposal)
 
         within(".supports") do
-          find(".in-favor a").click
+          accept_confirm { find(".in-favor a").click }
 
           expect(page).to have_content "1 support"
           expect(page).to have_content "You have already supported this proposal. Share it!"
@@ -251,7 +251,7 @@ describe "Votes" do
         visit proposals_path
 
         within("#proposal_#{proposal.id}") do
-          find(".in-favor a").click
+          accept_confirm { find(".in-favor a").click }
 
           expect(page).to have_content "1 support"
           expect(page).to have_content "You have already supported this proposal. Share it!"
@@ -263,7 +263,7 @@ describe "Votes" do
         visit proposals_path
 
         within("#proposal_#{proposal.id}") do
-          find(".in-favor a").click
+          accept_confirm { find(".in-favor a").click }
 
           expect(page).to have_content "You have already supported this proposal. Share it!"
         end


### PR DESCRIPTION
## Objectives

Supports for the proposals cannot be undone. This PR adds an alert to confirm support.

## Visual Changes

![proposal_support](https://user-images.githubusercontent.com/631897/85993495-b9e35c00-b9f6-11ea-8161-380cfda2a556.png)
