### PR TITLE
Fix design

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1820,6 +1820,14 @@ footer {
   line-height: $line-height * 2;
 }
 
+.fixed-mobile-content {
+  top: 0 !important;
+
+  &.is-stuck {
+    top: auto !important;
+  }
+}
+
 // 11. Polls
 // --------------------
 

--- a/app/views/admin/stats/budgets.html.erb
+++ b/app/views/admin/stats/budgets.html.erb
@@ -2,23 +2,25 @@
 
 <h2><%= t("admin.stats.budgets.title") %></h2>
 
-<% @budgets.each do |budget| %>
-  <table>
-    <tr id="<%= dom_id(budget) %>">
-      <td>
-        <strong><%= budget.name %></strong>
-      </td>
-      <td>
-        <%= link_to t("admin.stats.budgets.supporting_phase"),
-                    budget_supporting_admin_stats_path(budget_id: budget.id),
-                    class: "button hollow" %>
-
-        <% if can? :read_admin_stats, budget %>
-          <%= link_to t("admin.stats.budgets.balloting_phase"),
-                      budget_balloting_admin_stats_path(budget_id: budget.id),
+<table>
+  <tbody>
+    <% @budgets.each do |budget| %>
+      <tr id="<%= dom_id(budget) %>">
+        <td>
+          <strong><%= budget.name %></strong>
+        </td>
+        <td class="text-right">
+          <%= link_to t("admin.stats.budgets.supporting_phase"),
+                      budget_supporting_admin_stats_path(budget_id: budget.id),
                       class: "button hollow" %>
-        <% end %>
-      </td>
-    </tr>
-  </table>
-<% end %>
+
+          <% if can? :read_admin_stats, budget %>
+            <%= link_to t("admin.stats.budgets.balloting_phase"),
+                        budget_balloting_admin_stats_path(budget_id: budget.id),
+                        class: "button hollow" %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -25,44 +25,6 @@
       <aside class="small-12 medium-3 column">
         <%= render "/budgets/investments/author_actions", investment: investment %>
 
-        <% if investment.should_show_aside? %>
-          <% if investment.should_show_votes? %>
-            <div class="sidebar-divider"></div>
-            <h2><%= t("budgets.investments.show.supports") %></h2>
-            <div class="text-center">
-              <div id="<%= dom_id(investment) %>_votes">
-                <%= render "/budgets/investments/votes",
-                  investment: investment,
-                  investment_votes: investment_votes,
-                  vote_up_url: vote_budget_investment_path(investment.budget, investment, value: "yes"),
-                  vote_down_url: vote_budget_investment_path(investment.budget, investment, value: "no") %>
-              </div>
-            </div>
-          <% elsif investment.should_show_vote_count? %>
-            <div class="sidebar-divider"></div>
-            <h2><%= t("budgets.investments.show.supports") %></h2>
-            <div class="text-center">
-              <span class="total-supports">
-                <strong>
-                  <%= t("budgets.investments.investment.supports",
-                      count: investment.total_votes) %>
-                </strong>
-              </span>
-            </div>
-          <% elsif investment.should_show_ballots? %>
-            <div class="sidebar-divider"></div>
-            <h2><%= t("budgets.investments.show.votes") %></h2>
-            <div class="text-center">
-              <div id="<%= dom_id(investment) %>_ballot">
-                <%= render "ballot",
-                  investment: investment,
-                  investment_ids: investment_ids,
-                  ballot: ballot %>
-              </div>
-            </div>
-          <% end %>
-        <% end %>
-
         <% if investment.unfeasible? && investment.valuation_finished? %>
           <div class="callout warning">
             <%= sanitize(t("budgets.investments.show.project_unfeasible")) %>
@@ -100,6 +62,44 @@
             <div class="text-center" data-magellan>
               <%= link_to t("budgets.investments.show.see_price_explanation"),
                             "#price_explanation", class: "small" %>
+            </div>
+          <% end %>
+        <% end %>
+
+        <% if investment.should_show_aside? %>
+          <% if investment.should_show_votes? %>
+            <div class="sidebar-divider"></div>
+            <h2><%= t("budgets.investments.show.supports") %></h2>
+            <div class="text-center">
+              <div id="<%= dom_id(investment) %>_votes">
+                <%= render "/budgets/investments/votes",
+                  investment: investment,
+                  investment_votes: investment_votes,
+                  vote_up_url: vote_budget_investment_path(investment.budget, investment, value: "yes"),
+                  vote_down_url: vote_budget_investment_path(investment.budget, investment, value: "no") %>
+              </div>
+            </div>
+          <% elsif investment.should_show_vote_count? %>
+            <div class="sidebar-divider"></div>
+            <h2><%= t("budgets.investments.show.supports") %></h2>
+            <div class="text-center">
+              <span class="total-supports">
+                <strong>
+                  <%= t("budgets.investments.investment.supports",
+                      count: investment.total_votes) %>
+                </strong>
+              </span>
+            </div>
+          <% elsif investment.should_show_ballots? %>
+            <div class="sidebar-divider"></div>
+            <h2><%= t("budgets.investments.show.votes") %></h2>
+            <div class="text-center">
+              <div id="<%= dom_id(investment) %>_ballot">
+                <%= render "ballot",
+                  investment: investment,
+                  investment_ids: investment_ids,
+                  ballot: ballot %>
+              </div>
             </div>
           <% end %>
         <% end %>


### PR DESCRIPTION
## Objectives & Visual Changes

- Fix sidebar overlap on proposals supports.

<img width="321" alt="Screenshot 2020-06-30 at 16 49 52" src="https://user-images.githubusercontent.com/631897/86143370-a1f20200-baf4-11ea-9cf6-44f87059d0c6.png">

- Fix admin stats budgets table.

<img width="1248" alt="Screenshot 2020-06-30 at 16 56 22" src="https://user-images.githubusercontent.com/631897/86143387-a61e1f80-baf4-11ea-8e38-98a8b916fa03.png">

- Move investment status message to the top sidebar.

<img width="310" alt="Screenshot 2020-06-30 at 16 50 23" src="https://user-images.githubusercontent.com/631897/86143399-ab7b6a00-baf4-11ea-942d-b13d25a41a71.png">

